### PR TITLE
Add handling of JsonToken.Date

### DIFF
--- a/CoreTweet/Internal/Converters.cs
+++ b/CoreTweet/Internal/Converters.cs
@@ -113,6 +113,11 @@ namespace CoreTweet.Core
                     return DateTimeOffset.ParseExact(reader.Value as string, "ddd MMM dd HH:mm:ss K yyyy",
                                                   System.Globalization.DateTimeFormatInfo.InvariantInfo, 
                                                   System.Globalization.DateTimeStyles.AllowWhiteSpaces);
+                case JsonToken.Date:
+                    if (reader.Value is DateTimeOffset)
+                        return (DateTimeOffset)reader.Value;
+                    else
+                        return new DateTimeOffset(((DateTime)reader.Value).ToUniversalTime(), TimeSpan.Zero);
                 case JsonToken.Integer:
                     return InternalUtils.GetUnixTime((double)reader.Value);
                 


### PR DESCRIPTION
Issue #64 の修正です。CoreTweet 内の DateTimeOffsetConverter では JsonToken.Date という日時を示すトークンの処理が抜けていたため、この形で処理が可能だった ISO 8601 拡張フォーマットのトークン (JsonToken.Date) がうまく解釈できないということが根本的な原因でした。
本コミットにおいては JsonToken.Date の処理を行うことで Issue #64 における Trends API 関連のタイムスタンプを正しく処理できるようにしました。本トークンの Value は DateTimeOffset または DateTime ですが、後者の場合 UTC に変換後 UTC の DateTimeOffset に変換するということを行っており、ラウンドトリップ性が失われています――が、さしたる問題は出ないでしょう。
