### PR TITLE
Fix UNIX time parsing (value passed by JSON.NET is long)

### DIFF
--- a/CoreTweet/Internal/Converters.cs
+++ b/CoreTweet/Internal/Converters.cs
@@ -119,7 +119,7 @@ namespace CoreTweet.Core
                     else
                         return new DateTimeOffset(((DateTime)reader.Value).ToUniversalTime(), TimeSpan.Zero);
                 case JsonToken.Integer:
-                    return InternalUtils.GetUnixTime((double)(long)reader.Value);
+                    return InternalUtils.GetUnixTime((long)reader.Value);
                 
                 case JsonToken.Null:
                     return DateTimeOffset.Now;

--- a/CoreTweet/Internal/Utils.cs
+++ b/CoreTweet/Internal/Utils.cs
@@ -137,9 +137,11 @@ namespace CoreTweet.Core
             return string.Format("https://api.twitter.com/{0}/{1}.json", Property.ApiVersion, apiName);
         }
 
-        internal static DateTimeOffset GetUnixTime(double seconds)
+        internal static readonly DateTimeOffset unixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+
+        internal static DateTimeOffset GetUnixTime(long seconds)
         {
-            return new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero).AddSeconds(seconds);
+            return unixEpoch.AddTicks(checked(seconds * 10000000));
         }
 
         internal static RateLimit ReadRateLimit(HttpWebResponse response)
@@ -152,7 +154,7 @@ namespace CoreTweet.Core
                 {
                     Limit = int.Parse(limit),
                     Remaining = int.Parse(remaining),
-                    Reset = InternalUtils.GetUnixTime(double.Parse(reset))
+                    Reset = InternalUtils.GetUnixTime(long.Parse(reset))
                 }
                 : null;
         }
@@ -171,7 +173,7 @@ namespace CoreTweet.Core
                 {
                     Limit = int.Parse(limit),
                     Remaining = int.Parse(remaining),
-                    Reset = InternalUtils.GetUnixTime(double.Parse(reset))
+                    Reset = InternalUtils.GetUnixTime(long.Parse(reset))
                 };
         }
 #endif

--- a/CoreTweet/Request.cs
+++ b/CoreTweet/Request.cs
@@ -220,8 +220,7 @@ namespace CoreTweet
             var ret = new Dictionary<string, string>() {
                 {"oauth_consumer_key", consumerKey},
                 {"oauth_signature_method", "HMAC-SHA1"},
-                {"oauth_timestamp", ((DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).Ticks
-                    / 10000000L).ToString("D")},
+                {"oauth_timestamp", ((DateTimeOffset.UtcNow - InternalUtils.unixEpoch).Ticks / 10000000L).ToString("D")},
                 {"oauth_nonce", new Random().Next(int.MinValue, int.MaxValue).ToString("X")},
                 {"oauth_version", "1.0"}
             };


### PR DESCRIPTION
JSON.NET から UNIX タイムとして渡される値が double ではなく long であるため、reader.Value の unboxing に失敗します (ここで扱われる UNIX タイムは今のところ API レート取得 API [application/rate_limit_status] においてのみ確認しています)。そのため、追加のキャストによってこの問題を解決します。
この問題ですが……どうも CoreTweet 側というより JSON.NET 側の極端なわかりづらさによって生まれたバグに見えます。個人的には、最悪 JSON.NET から別の JSON ライブラリに移行することを考えた方が良いのではないか、と考えます (.NET 3.5 から標準の JSON シリアライザがあるので、それで何とかならないか試行錯誤しています)。
