### PR TITLE
Fix max_id and since_id parameter documentation

### DIFF
--- a/CoreTweet/Rest/Favorites.Async.cs
+++ b/CoreTweet/Rest/Favorites.Async.cs
@@ -40,8 +40,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>long</c> id (optional)</para>
         /// <para>- <c>string</c> screen_name (optonal)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id (optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id (optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// </summary>
         /// <param name="parameters">The parameters.</param>
@@ -60,8 +60,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>long</c> id (optional)</para>
         /// <para>- <c>string</c> screen_name (optonal)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id (optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id (optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// </summary>
         /// <param name="parameters">The parameters.</param>
@@ -81,8 +81,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>long</c> id (optional)</para>
         /// <para>- <c>string</c> screen_name (optonal)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id (optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id (optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// </summary>
         /// <param name="parameters">The parameters.</param>

--- a/CoreTweet/Rest/Favorites.cs
+++ b/CoreTweet/Rest/Favorites.cs
@@ -44,8 +44,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>long</c> id (optional)</para>
         /// <para>- <c>string</c> screen_name (optonal)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id (optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id (optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// </summary>
         /// <param name="parameters">The parameters.</param>
@@ -61,8 +61,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>long</c> id (optional)</para>
         /// <para>- <c>string</c> screen_name (optonal)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id (optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id (optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// </summary>
         /// <param name="parameters">The parameters.</param>
@@ -78,8 +78,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>long</c> id (optional)</para>
         /// <para>- <c>string</c> screen_name (optonal)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id (optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id (optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// </summary>
         /// <param name="parameters">The parameters.</param>

--- a/CoreTweet/Rest/Statuses.Async.cs
+++ b/CoreTweet/Rest/Statuses.Async.cs
@@ -41,8 +41,8 @@ namespace CoreTweet.Rest
         /// <para>This method can only return up to 800 tweets.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -63,8 +63,8 @@ namespace CoreTweet.Rest
         /// <para>This method can only return up to 800 tweets.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -86,8 +86,8 @@ namespace CoreTweet.Rest
         /// <para>This method can only return up to 800 tweets.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -113,8 +113,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>int</c> user_id (optional)</para>
         /// <para>- <c>string</c> screen_name (optional)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_rts (optional)</para>
@@ -140,8 +140,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>int</c> user_id (optional)</para>
         /// <para>- <c>string</c> screen_name (optional)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_rts (optional)</para>
@@ -168,8 +168,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>int</c> user_id (optional)</para>
         /// <para>- <c>string</c> screen_name (optional)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_rts (optional)</para>
@@ -193,8 +193,8 @@ namespace CoreTweet.Rest
         /// <para>It is more volatile for users that follow many users or follow users who tweet frequently.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -217,8 +217,8 @@ namespace CoreTweet.Rest
         /// <para>It is more volatile for users that follow many users or follow users who tweet frequently.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -242,8 +242,8 @@ namespace CoreTweet.Rest
         /// <para>It is more volatile for users that follow many users or follow users who tweet frequently.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -265,8 +265,8 @@ namespace CoreTweet.Rest
         /// <para>This timeline is a subset of the user's GET statuses/user_timeline.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// <para>- <c>bool</c> include_user_entities (optional)</para>
@@ -286,8 +286,8 @@ namespace CoreTweet.Rest
         /// <para>This timeline is a subset of the user's GET statuses/user_timeline.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// <para>- <c>bool</c> include_user_entities (optional)</para>
@@ -308,8 +308,8 @@ namespace CoreTweet.Rest
         /// <para>This timeline is a subset of the user's GET statuses/user_timeline.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// <para>- <c>bool</c> include_user_entities (optional)</para>

--- a/CoreTweet/Rest/Statuses.cs
+++ b/CoreTweet/Rest/Statuses.cs
@@ -45,8 +45,8 @@ namespace CoreTweet.Rest
         /// <para>This method can only return up to 800 tweets.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -64,8 +64,8 @@ namespace CoreTweet.Rest
         /// <para>This method can only return up to 800 tweets.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -83,8 +83,8 @@ namespace CoreTweet.Rest
         /// <para>This method can only return up to 800 tweets.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -106,8 +106,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>int</c> user_id (optional)</para>
         /// <para>- <c>string</c> screen_name (optional)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_rts (optional)</para>
@@ -130,8 +130,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>int</c> user_id (optional)</para>
         /// <para>- <c>string</c> screen_name (optional)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_rts (optional)</para>
@@ -154,8 +154,8 @@ namespace CoreTweet.Rest
         /// <para>- <c>int</c> user_id (optional)</para>
         /// <para>- <c>string</c> screen_name (optional)</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_rts (optional)</para>
@@ -175,8 +175,8 @@ namespace CoreTweet.Rest
         /// <para>It is more volatile for users that follow many users or follow users who tweet frequently.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -196,8 +196,8 @@ namespace CoreTweet.Rest
         /// <para>It is more volatile for users that follow many users or follow users who tweet frequently.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -217,8 +217,8 @@ namespace CoreTweet.Rest
         /// <para>It is more volatile for users that follow many users or follow users who tweet frequently.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> contributor_details (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
@@ -236,8 +236,8 @@ namespace CoreTweet.Rest
         /// <para>This timeline is a subset of the user's GET statuses/user_timeline.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// <para>- <c>bool</c> include_user_entities (optional)</para>
@@ -254,8 +254,8 @@ namespace CoreTweet.Rest
         /// <para>This timeline is a subset of the user's GET statuses/user_timeline.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// <para>- <c>bool</c> include_user_entities (optional)</para>
@@ -272,8 +272,8 @@ namespace CoreTweet.Rest
         /// <para>This timeline is a subset of the user's GET statuses/user_timeline.</para>
         /// <para>Available parameters:</para>
         /// <para>- <c>int</c> count (optional)</para>
-        /// <para>- <c>int</c> since_id(optional)</para>
-        /// <para>- <c>int</c> max_id (optional)</para>
+        /// <para>- <c>long</c> since_id(optional)</para>
+        /// <para>- <c>long</c> max_id (optional)</para>
         /// <para>- <c>bool</c> trim_user (optional)</para>
         /// <para>- <c>bool</c> include_entities (optional)</para>
         /// <para>- <c>bool</c> include_user_entities (optional)</para>


### PR DESCRIPTION
Their type should be `long`, not `int`.
Please note that there's no implementation issue because CoreTweet accepts max_id and since_id as long numbers.

……と説明にあるように、ドキュメントにおける max_id と since_id が本来あるべき long 型ではなく int 型と記されていたことに関する修正で、実装に関する修正はありません (CoreTweet がパラメータの型を柔軟に受け付けるため; テストで実装上は問題が無いことは確認)。
