### PR TITLE
Fix follow parameter documentation for streaming

### DIFF
--- a/CoreTweet/Streaming/Stream.cs
+++ b/CoreTweet/Streaming/Stream.cs
@@ -134,7 +134,7 @@ namespace CoreTweet.Streaming
         /// <para>Available parameters: </para>
         /// <para>*Note: In filter stream, at least one predicate parameter (follow, locations, or track) must be specified.</para>
         /// <para><c>bool</c> stall_warnings (optional)"/> : Specifies whether stall warnings should be delivered.</para>
-        /// <para><c>string / IEnumerable&lt;string&gt;</c> follow (optional*, required in site stream, ignored in user stream)</para>
+        /// <para><c>string / IEnumerable&lt;long&gt;</c> follow (optional*, required in site stream, ignored in user stream)</para>
         /// <para><c>string / IEnumerable&lt;string&gt;</c> track (optional*)</para>
         /// <para><c>string / IEnumerable&lt;string&gt;</c> location (optional*)</para>
         /// <para><c>string</c> with (optional)</para>


### PR DESCRIPTION
Twitter は streaming API の follow パラメータにおいて screen name ではなく user ID [のコンマ区切りリスト] を要求しており、また CoreTweet においては user ID の表現に用いられている型は long です。
そのため、このコンテキストで推奨される理想的な型は IEnumerable&lt;string&gt; ではなく IEnumerable&lt;long&gt; です (IEnumerable&lt;string&gt; でも使うこと自体は可能ですし、現在の実装では IEnumerable&lt;long&gt; も適切に扱いますが)。

Although current 'follow' parameter documentation is okay to use, ideal type preferred for this context is 'IEnumerable&lt;long&gt;' rather than 'IEnumerable&lt;string&gt;' (since Twitter accepts user IDs rather than screen names and we use 'long' as user IDs).

Reference:
- https://dev.twitter.com/docs/api/1.1/post/statuses/filter
