### PR TITLE
Add UseCompressionOnStreaming parameter

### DIFF
--- a/CoreTweet/ConnectionOptions.cs
+++ b/CoreTweet/ConnectionOptions.cs
@@ -53,6 +53,7 @@ namespace CoreTweet
             this.UserAgent = "CoreTweet";
 #if !(PCL || WP)
             this.UseCompression = true;
+            this.UseCompressionOnStreaming = false;
 #endif
         }
 
@@ -106,9 +107,14 @@ namespace CoreTweet
 
 #if !(PCL || WP)
         /// <summary>
-        /// Gets or sets whether the compression is used.
+        /// Gets or sets whether the compression is used on non-streaming requests.
         /// </summary>
         public bool UseCompression { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the compression is used on streaming requests.
+        /// </summary>
+        public bool UseCompressionOnStreaming { get; set; }
 #endif
 
 #if !PCL
@@ -138,6 +144,7 @@ namespace CoreTweet
                 UserAgent = this.UserAgent,
 #if !(PCL || WP)
                 UseCompression = this.UseCompression,
+                UseCompressionOnStreaming = this.UseCompressionOnStreaming,
 #endif
 #if !PCL
                 BeforeRequestAction = this.BeforeRequestAction

--- a/CoreTweet/Internal/TokensBase.Async.cs
+++ b/CoreTweet/Internal/TokensBase.Async.cs
@@ -200,6 +200,9 @@ namespace CoreTweet.Core
         public Task<AsyncResponse> SendStreamingRequestAsync(MethodType type, string url, IEnumerable<KeyValuePair<string, object>> parameters, CancellationToken cancellationToken = default(CancellationToken))
         {
             var options = this.ConnectionOptions != null ? (ConnectionOptions)this.ConnectionOptions.Clone() : new ConnectionOptions();
+#if !(PCL || WP)
+            options.UseCompression = options.UseCompressionOnStreaming;
+#endif
 #if !(PCL || WIN_RT || WP)
             options.ReadWriteTimeout = Timeout.Infinite;
 #endif

--- a/CoreTweet/Internal/TokensBase.cs
+++ b/CoreTweet/Internal/TokensBase.cs
@@ -319,6 +319,9 @@ namespace CoreTweet.Core
         public HttpWebResponse SendStreamingRequest(MethodType type, string url, IEnumerable<KeyValuePair<string, object>> parameters)
         {
             var options = this.ConnectionOptions != null ? (ConnectionOptions)this.ConnectionOptions.Clone() : new ConnectionOptions();
+#if !(PCL || WP)
+            options.UseCompression = options.UseCompressionOnStreaming;
+#endif
             options.ReadWriteTimeout = Timeout.Infinite;
             return this.SendRequestImpl(type, url, parameters, options);
         }


### PR DESCRIPTION
UseCompression is very useful on non-streaming request. However, this will lead to the undesirable behavior on streaming requests because Twitter server 'buffers' messages and there are no ways to determine how many messages 'buffered'.
This commit adds UseCompressionOnStreaming option [default false] to make streaming behavior desirable and predictable.

――のように、ConnectionOptions 中の UseCompression プロパティが streaming リクエストにおいて予期しない動作を生み出す問題をオプションの追加により修正します。
どうやら Twitter サーバは gzip を受け取る user stream においてメッセージをバッファするらしく、リアルタイムでメッセージを取得できなくなります。その上、このバッファされたメッセージ数を知る方法が存在せず、接続切断時などに予測出来ない量のメッセージが消失します。これは情報収集系の bot 作成に悪影響をもたらします。そのため UseCompressionOnStreaming オプションを追加し、当面の問題に対処します。

――が、マージする前に確認できていない問題をこれを書いている最中に発見 (Stream 側でバッファされているせいで Twitter サーバから送信されている情報を十分に取れない可能性がある) しました。こちらの場合、上記の対処手段は workaround 以上の意味がない (むしろ無駄にコードを増やす有害な) ものになってしまいます。これをポストしてからパケットキャプチャでテストしてみます。それまではマージをしないようにお願い致します。
