### PR TITLE
Add feature of alternative profile image sizes

### DIFF
--- a/CoreTweet/Objects/User.cs
+++ b/CoreTweet/Objects/User.cs
@@ -329,7 +329,7 @@ namespace CoreTweet
         /// Returns the URI for given profile image URI and alternative size. See User Profile Images and Banners.
         /// </summary>
         /// <returns>The alternative profile image URI.</returns>
-        /// <param name="uri">The original URI of <c>ProfileImageUrl</c> or <c>ProfileImageUrlHttps</c>.</param>
+        /// <param name="uri">The original URI of <see cref="ProfileImageUrl" /> or <see cref="ProfileImageUrlHttps" />.</param>
         /// <param name="size">Size of the image to obtain ("orig" to obtain the original size).</param>
         private static Uri GetAlternativeProfileImageUri(Uri uri, string size)
         {


### PR DESCRIPTION
User.ProfileImageUrl and User.ProfileImageUrlHttps returns "normal" variant of the user's uploaded image and there's no Twitter API to obtain other variants.

According to https://dev.twitter.com/docs/user-profile-images-and-banners, replacing URL string will simply work.

This commit adds two new methods GetProfileImageUrl and GetProfileImageUrlHttps which accepts alternative variant size as 'size' parameter (expected values are "normal", "bigger", "mini", "orig" and null-or-empty string [implies "orig"]).

User のプロファイル画像 (profile_image_url および profile_image_url_https) は現在 normal サイズのみを返すようになっており、他のサイズを返す API が存在しません。そのため、2 つの (プロパティに関連する) メソッドを追加することで、他のサイズ (バリアント) の URL を生成できるようにします。
バリアント名は Twitter ページ準拠 (基本的動作は、"_normal" をサイズ別の文字列に置換) であり、"orig" バリアント (またはフォールバック用の空文字列か null) を指定することで元 URL の "_normal" を削除します。

もしかするとバリアント名は enum 値にした方が良かったかもしれませんが、banner サイズに様々なものがあり、容易に変更されうる事実と併せて string のままにしています。
