### PR TITLE
Add workaround to disable Keep-Alive requests

### DIFF
--- a/CoreTweet/ConnectionOptions.cs
+++ b/CoreTweet/ConnectionOptions.cs
@@ -54,6 +54,7 @@ namespace CoreTweet
 #if !(PCL || WP)
             this.UseCompression = true;
             this.UseCompressionOnStreaming = false;
+            this.DisableKeepAlive = true;
 #endif
         }
 
@@ -115,6 +116,11 @@ namespace CoreTweet
         /// Gets or sets whether the compression is used on streaming requests.
         /// </summary>
         public bool UseCompressionOnStreaming { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether Keep-Alive requests are disabled.
+        /// </summary>
+        public bool DisableKeepAlive { get; set; }
 #endif
 
 #if !PCL
@@ -145,6 +151,7 @@ namespace CoreTweet
 #if !(PCL || WP)
                 UseCompression = this.UseCompression,
                 UseCompressionOnStreaming = this.UseCompressionOnStreaming,
+                DisableKeepAlive = this.DisableKeepAlive,
 #endif
 #if !PCL
                 BeforeRequestAction = this.BeforeRequestAction

--- a/CoreTweet/Request.Async.cs
+++ b/CoreTweet/Request.Async.cs
@@ -188,9 +188,16 @@ namespace CoreTweet
 #if WIN8
             req.Headers.ExpectContinue = false;
             req.Headers.Authorization = new AuthenticationHeaderValue(splitAuth[0], splitAuth[1]);
+            if (options.DisableKeepAlive)
+                req.Headers.ConnectionClose = true;
 #else
             req.Headers.Expect.Clear();
             req.Headers.Authorization = new HttpCredentialsHeaderValue(splitAuth[0], splitAuth[1]);
+            if (options.DisableKeepAlive)
+            {
+                req.Headers.Connection.Clear();
+                req.Headers.Connection.Add(new HttpConnectionOptionHeaderValue("close"));
+            }
 #endif
             if(options.BeforeRequestAction != null)
                 options.BeforeRequestAction(req);
@@ -271,6 +278,8 @@ namespace CoreTweet
                 req.Proxy = options.Proxy;
                 if(options.UseCompression)
                     req.AutomaticDecompression = CompressionType;
+                if (options.DisableKeepAlive)
+                    req.KeepAlive = false;
 #endif
                 req.Headers[HttpRequestHeader.Authorization] = authorizationHeader;
 #if !PCL
@@ -366,6 +375,8 @@ namespace CoreTweet
                 req.Proxy = options.Proxy;
                 if(options.UseCompression)
                     req.AutomaticDecompression = CompressionType;
+                if (options.DisableKeepAlive)
+                    req.KeepAlive = false;
 #endif
 #if !PCL
                 req.UserAgent = options.UserAgent;
@@ -524,6 +535,8 @@ namespace CoreTweet
                 req.SendChunked = true;
                 if(options.UseCompression)
                     req.AutomaticDecompression = CompressionType;
+                if (options.DisableKeepAlive)
+                    req.KeepAlive = false;
 #endif
 #if !PCL
                 req.UserAgent = options.UserAgent;

--- a/CoreTweet/Request.cs
+++ b/CoreTweet/Request.cs
@@ -138,6 +138,8 @@ namespace CoreTweet
             req.Headers.Add(HttpRequestHeader.Authorization, authorizationHeader);
             if(options.UseCompression)
                 req.AutomaticDecompression = CompressionType;
+            if (options.DisableKeepAlive)
+                req.KeepAlive = false;
             if(options.BeforeRequestAction != null) options.BeforeRequestAction(req);
             return (HttpWebResponse)req.GetResponse();
         }
@@ -159,6 +161,8 @@ namespace CoreTweet
             req.Headers.Add(HttpRequestHeader.Authorization, authorizationHeader);
             if(options.UseCompression)
                 req.AutomaticDecompression = CompressionType;
+            if (options.DisableKeepAlive)
+                req.KeepAlive = false;
             if(options.BeforeRequestAction != null) options.BeforeRequestAction(req);
             using(var reqstr = req.GetRequestStream())
                 reqstr.Write(data, 0, data.Length);
@@ -181,6 +185,8 @@ namespace CoreTweet
             req.SendChunked = true;
             if(options.UseCompression)
                 req.AutomaticDecompression = CompressionType;
+            if (options.DisableKeepAlive)
+                req.KeepAlive = false;
             if (options.BeforeRequestAction != null) options.BeforeRequestAction(req);
             using(var reqstr = req.GetRequestStream())
                 WriteMultipartFormData(reqstr, boundary, prm);


### PR DESCRIPTION
最近、Twitter 側のサーバーの変化のためか一部リクエストがタイムアウトするようになりました。
原因は Keep-Alive に因るようで、OpenTween はこの問題に対し、Keep-Alive リクエストを無効にすることで対処を行いました (http://moccosblue.blogspot.jp/2014/09/opentween.html )。

この pull request では Keep-Alive を無効にするオプション (必要なら Keep-Alive workaround を無効にしてテストできるように) を追加した上で、これが追加されているときに Keep-Alive を可能な限り無効にしようとします。
- HttpWebRequest.KeepAlive プロパティに false を設定
- HttpRequestMessage.Headers.ConnectionClose を true に設定 (Connection: close で間接的に Keep-Alive を無効化)
- HttpRequestMessage.Headers.Connection を "close" に設定 (同上)

例によってこの回避手段は次のビルド構成に使えません。
- CoreTweet.Pcl (PCL 構成)
- CoreTweet.wp8 (Windows Phone 8.0 用構成)

またこちらは十分にテストができていないようです。
- CoreTweet.Universal (Windows 8.1 では大丈夫に見えるが、Windows Phone 8.1 環境において、エミュレータしかないため強制的にデバッガのプロキシを通っており、ちゃんと動いているかどうか判別不能)
