### PR TITLE
fixed sha1 case when msg was between 57 and 64 long

### DIFF
--- a/CoreTweet/Internal/SecurityUtils.cs
+++ b/CoreTweet/Internal/SecurityUtils.cs
@@ -78,7 +78,10 @@ namespace CoreTweet.Core
             var msgList = message.ToList();
             var ml = msgList.Count * 8L;
             msgList.Add(0x80);
-            msgList.AddRange(Enumerable.Repeat((byte)0, 64 - (msgList.Count % 64) - 8));
+            int bytesToAdd = 64 - (msgList.Count % 64) - 8;
+            if (bytesToAdd < 0)
+                bytesToAdd += 64;
+            msgList.AddRange(Enumerable.Repeat((byte)0, bytesToAdd));
             msgList.AddRange(GetBytes(ml));
             var msg = msgList.ToArray();
 


### PR DESCRIPTION
SHA1 implementation was throwing an exception when msg length was between 56 and 64 (when there was no space to add further 8 bytes)
