### PR TITLE
Use Windows.Web.Http for Windows10

### DIFF
--- a/CoreTweet.Shared/ConnectionOptions.cs
+++ b/CoreTweet.Shared/ConnectionOptions.cs
@@ -25,7 +25,7 @@ using System;
 using System.Net;
 
 #if WIN_RT
-using System.Net.Http;
+using Windows.Web.Http;
 #endif
 
 namespace CoreTweet


### PR DESCRIPTION
System.Net.Http だと
```
NotSupportedException
Message: "HttpVersion Http20"
```
の例外が発生するので、 Windows.Web.Http を使わないといけない。しかし #88 問題はどうしようか。