### PR TITLE
Make up http:// for invalid URL

### DIFF
--- a/CoreTweet.Shared/Internal/Converters.cs
+++ b/CoreTweet.Shared/Internal/Converters.cs
@@ -55,7 +55,18 @@ namespace CoreTweet.Core
             switch(reader.TokenType)
             {
                 case JsonToken.String:
-                    return new Uri(reader.Value as String);
+                    Uri uri;
+                    string value = reader.Value as String;
+                    if(Uri.TryCreate(value, UriKind.Absolute, out uri))
+                    {
+                        return uri;
+                    }
+                    else
+                    {
+                        // some uri has no scheme
+                        var builder = new UriBuilder("http", value);
+                        return builder.Uri;
+                    }
                 case JsonToken.Null:
                     return null;
             }


### PR DESCRIPTION
不正な URL のパースに失敗する問題の対処。
具体的には以下のコードで失敗します。

``` C#
  var tokens = CoreTweet.Tokens.Create("", "", "", "");
  var searchResult = tokens.Search.Tweets(new
  {
      q = "あつい",
      since_id = 627864649686495233,
      max_id = 627864649686495234,
  });

```

この PR は http を補足してパースを成功させるように変更したものですが、
そもそも URL を string として扱うほうがよいかもしれません......