### PR TITLE
C# 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: csharp
 
-cache:
-  - apt
+sudo: false
 
-install:
-  - sudo apt-get -y install doxygen
+addons:
+  apt:
+    packages:
+    - doxygen
 
 script:
   - make all

--- a/CoreTweet-All.sln
+++ b/CoreTweet-All.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreTweet", "CoreTweet\CoreTweet.csproj", "{B8237636-EC72-47BD-887B-E66D4123F422}"
 EndProject

--- a/CoreTweet.Shared/Attribute.cs
+++ b/CoreTweet.Shared/Attribute.cs
@@ -43,7 +43,7 @@ namespace CoreTweet
         public object DefaultValue { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CoreTweet.TwitterParameterAttribute"/> class.
+        /// Initializes a new instance of the <see cref="TwitterParameterAttribute"/> class.
         /// </summary>
         /// <param name="name">Name.</param>
         /// <param name="defaultValue">Default value.</param>

--- a/CoreTweet.Shared/ConnectionOptions.cs
+++ b/CoreTweet.Shared/ConnectionOptions.cs
@@ -39,7 +39,7 @@ namespace CoreTweet
 #endif
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CoreTweet.ConnectionOptions"/> class.
+        /// Initializes a new instance of the <see cref="ConnectionOptions"/> class.
         /// </summary>
         public ConnectionOptions()
         {

--- a/CoreTweet.Shared/Exceptions.cs
+++ b/CoreTweet.Shared/Exceptions.cs
@@ -50,7 +50,7 @@ namespace CoreTweet
         public string Json { get; private set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CoreTweet.ParsingException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// Initializes a new instance of the <see cref="ParsingException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="json">The JSON that couldn't be parsed.</param>
@@ -66,7 +66,7 @@ namespace CoreTweet
     /// </summary>
     public class TwitterException : Exception, ITwitterResponse
     {
-        private TwitterException(HttpStatusCode status, Error[] errors, RateLimit rateLimit, string json, WebException innerException)
+        private TwitterException(HttpStatusCode status, Error[] errors, RateLimit rateLimit, string json, Exception innerException)
             : base(errors[0].Message, innerException)
         {
             this.Status = status;
@@ -127,10 +127,10 @@ namespace CoreTweet
         }
 
         /// <summary>
-        /// Create a <see cref="CoreTweet.TwitterException"/> instance from the <see cref="System.Net.WebException"/>.
+        /// Create a <see cref="TwitterException"/> instance from the <see cref="WebException"/>.
         /// </summary>
-        /// <param name="ex">The thrown <see cref="System.Net.WebException"/>.</param>
-        /// <returns><see cref="CoreTweet.TwitterException"/> instance or null.</returns>
+        /// <param name="ex">The thrown <see cref="WebException"/>.</param>
+        /// <returns><see cref="TwitterException"/> instance or null.</returns>
         public static TwitterException Create(WebException ex)
         {
             try
@@ -147,9 +147,9 @@ namespace CoreTweet
 
 #if WIN_RT
         /// <summary>
-        /// Create a <see cref="CoreTweet.TwitterException"/> instance from the <see cref="CoreTweet.AsyncResponse"/>.
+        /// Create a <see cref="TwitterException"/> instance from the <see cref="AsyncResponse"/>.
         /// </summary>
-        /// <returns><see cref="CoreTweet.TwitterException"/> instance or null.</returns>
+        /// <returns><see cref="TwitterException"/> instance or null.</returns>
         public static async Task<TwitterException> Create(AsyncResponse response)
         {
             try

--- a/CoreTweet.Shared/Internal/ApiProviderBase.cs
+++ b/CoreTweet.Shared/Internal/ApiProviderBase.cs
@@ -32,18 +32,12 @@ namespace CoreTweet.Core
         /// <summary>
         /// Gets or sets the OAuth tokens.
         /// </summary>
-        protected internal TokensBase Tokens { get; set; }
+        protected TokensBase Tokens { get; set; }
 
         /// <summary>
         /// Gets the tokens being used in this instance.
         /// </summary>
-        public TokensBase IncludedTokens
-        {
-            get
-            {
-                return this.Tokens;
-            }
-        }
+        public TokensBase IncludedTokens => this.Tokens;
 
         internal ApiProviderBase(TokensBase tokens)
         {

--- a/CoreTweet.Shared/Internal/CoreBase.cs
+++ b/CoreTweet.Shared/Internal/CoreBase.cs
@@ -76,7 +76,7 @@ namespace CoreTweet.Core
             return ConvertBase<List<T>>(json, jsonPath);
         }
 
-        internal static readonly string JsonPathPrefix = "";
+        internal const string JsonPathPrefix = "";
     }
 
 }

--- a/CoreTweet.Shared/Internal/ITwitterResponse.cs
+++ b/CoreTweet.Shared/Internal/ITwitterResponse.cs
@@ -1,6 +1,25 @@
-﻿using System;
+﻿// Copyright (c) 2013-2015 CoreTweet Development Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace CoreTweet.Core
 {
@@ -65,40 +84,22 @@ namespace CoreTweet.Core
         /// <summary>
         /// Gets the number of elements actually contained in the <see cref="ListedResponse&lt;T&gt;"/>.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return this.innerList.Count;
-            }
-        }
+        public int Count => this.innerList.Count;
 
         /// <summary>
         /// Gets the element at the specified index.
         /// </summary>
         /// <param name="index">The zero-based index of the element to get or set.</param>
         /// <returns>The element at the specified index.</returns>
-        public T this[int index]
-        {
-            get
-            {
-                return this.innerList[index];
-            }
-        }
+        public T this[int index] => this.innerList[index];
 
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>An IEnumerator object that can be used to iterate through the collection.</returns>
-        public IEnumerator<T> GetEnumerator()
-        {
-            return this.innerList.GetEnumerator();
-        }
+        public IEnumerator<T> GetEnumerator() => this.innerList.GetEnumerator();
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 
     /// <summary>
@@ -150,22 +151,13 @@ namespace CoreTweet.Core
         /// </summary>
         /// <param name="key">The key to locate.</param>
         /// <returns><c>true</c> if the read-only dictionary contains an element that has the specified key; otherwise, <c>false</c>.</returns>
-        public bool ContainsKey(TKey key)
-        {
-            return this.innerDictionary.ContainsKey(key);
-        }
+        public bool ContainsKey(TKey key) => this.innerDictionary.ContainsKey(key);
 
         /// <summary>
         /// Gets an enumerable collection that contains the keys in the read-only dictionary.
         /// </summary>
         /// <value>An enumerable collection that contains the keys in the read-only dictionary.</value>
-        public IEnumerable<TKey> Keys
-        {
-            get
-            {
-                return this.innerDictionary.Keys;
-            }
-        }
+        public IEnumerable<TKey> Keys => this.innerDictionary.Keys;
 
         /// <summary>
         /// Gets the value that is associated with the specified key.
@@ -176,60 +168,33 @@ namespace CoreTweet.Core
         /// This parameter is passed uninitialized.
         /// </param>
         /// <returns><c>true</c> if the <see cref="CoreTweet.Core.DictionaryResponse&lt;TKey, TValue&gt;"/> contains an element that has the specified key; otherwise, <c>false</c>.</returns>
-        public bool TryGetValue(TKey key, out TValue value)
-        {
-            return this.innerDictionary.TryGetValue(key, out value);
-        }
+        public bool TryGetValue(TKey key, out TValue value) => this.innerDictionary.TryGetValue(key, out value);
 
         /// <summary>
         /// Gets an enumerable collection that contains the values in the read-only dictionary.
         /// </summary>
         /// <value>An enumerable collection that contains the values in the read-only dictionary.</value>
-        public IEnumerable<TValue> Values
-        {
-            get
-            {
-                return this.innerDictionary.Values;
-            }
-        }
+        public IEnumerable<TValue> Values => this.innerDictionary.Values;
 
         /// <summary>
         /// Gets the element that has the specified key in the read-only dictionary.
         /// </summary>
         /// <param name="key">The key to locate.</param>
         /// <returns>The element that has the specified key in the read-only dictionary.</returns>
-        public TValue this[TKey key]
-        {
-            get
-            {
-                return this.innerDictionary[key];
-            }
-        }
+        public TValue this[TKey key] => this.innerDictionary[key];
 
         /// <summary>
         /// Gets the number of elements in the collection.
         /// </summary>
         /// <value>The number of elements in the collection.</value>
-        public int Count
-        {
-            get
-            {
-                return this.innerDictionary.Count;
-            }
-        }
+        public int Count => this.innerDictionary.Count;
 
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>An IEnumerator object that can be used to iterate through the collection.</returns>
-        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
-        {
-            return this.innerDictionary.GetEnumerator();
-        }
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => this.innerDictionary.GetEnumerator();
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }

--- a/CoreTweet.Shared/Internal/SecurityUtils.cs
+++ b/CoreTweet.Shared/Internal/SecurityUtils.cs
@@ -151,13 +151,8 @@ namespace CoreTweet.Core
             var inner = Sha1(k.Zip(ipad, (x, y) => (byte)(x ^ y)).Concat(message ?? Enumerable.Empty<byte>()));
             return Sha1(k.Zip(opad, (x, y) => (byte)(x ^ y)).Concat(inner));
 #else
-            var keyArray = key as byte[];
-            if(keyArray == null) keyArray = key.ToArray();
-            var messageArray = message as byte[];
-                if(messageArray == null)
-                    messageArray = message != null
-                        ? message.ToArray()
-                        : new byte[] { };
+            var keyArray = key as byte[] ?? key.ToArray();
+            var messageArray = message as byte[] ?? (message?.ToArray() ?? new byte[] { });
 #if WIN_RT
             var prov = MacAlgorithmProvider.OpenAlgorithm(MacAlgorithmNames.HmacSha1);
             var buffer = CryptographicEngine.Sign(

--- a/CoreTweet.Shared/Internal/TokensBase.Async.cs
+++ b/CoreTweet.Shared/Internal/TokensBase.Async.cs
@@ -27,7 +27,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -252,28 +251,26 @@ namespace CoreTweet.Core
                     )
                     .ResponseCallback(cancellationToken);
                 }
-                else
-                {
-                    var header = CreateAuthorizationHeader(type, url, prmArray);
-                    return (type == MethodType.Get
-                        ? Request.HttpGetAsync(
-                            url,
-                            prmArray,
-                            header,
-                            options,
-                            cancellationToken
-                        )
-                        : Request.HttpPostAsync(
-                            url,
-                            prmArray,
-                            header,
-                            options,
-                            cancellationToken
-                        )
+
+                var header = CreateAuthorizationHeader(type, url, prmArray);
+                return (type == MethodType.Get
+                    ? Request.HttpGetAsync(
+                        url,
+                        prmArray,
+                        header,
+                        options,
+                        cancellationToken
                     )
-                    .ResponseCallback(cancellationToken);
-                }
-            }).Unwrap();
+                    : Request.HttpPostAsync(
+                        url,
+                        prmArray,
+                        header,
+                        options,
+                        cancellationToken
+                    )
+                )
+                .ResponseCallback(cancellationToken);
+            }, cancellationToken).Unwrap();
         }
     }
 }

--- a/CoreTweet.Shared/Internal/TokensBase.cs
+++ b/CoreTweet.Shared/Internal/TokensBase.cs
@@ -62,80 +62,79 @@ namespace CoreTweet.Core
         /// <summary>
         /// Gets the wrapper of account.
         /// </summary>
-        public Account Account { get { return new Account(this); } }
+        public Account Account => new Account(this);
         /// <summary>
         /// Gets the wrapper of application.
         /// </summary>
-        public Application Application { get { return new Application(this); } }
+        public Application Application => new Application(this);
         /// <summary>
         /// Gets the wrapper of blocks.
         /// </summary>
-        public Blocks Blocks { get { return new Blocks(this); } }
+        public Blocks Blocks => new Blocks(this);
         /// <summary>
         /// Gets the wrapper of direct_messages.
         /// </summary>
-        public DirectMessages DirectMessages { get { return new DirectMessages(this); } }
+        public DirectMessages DirectMessages => new DirectMessages(this);
         /// <summary>
         /// Gets the wrapper of favorites.
         /// </summary>
-        public Favorites Favorites { get { return new Favorites(this); } }
+        public Favorites Favorites => new Favorites(this);
         /// <summary>
         /// Gets the wrapper of friends.
         /// </summary>
-        public Friends Friends { get { return new Friends(this); } }
+        public Friends Friends => new Friends(this);
         /// <summary>
         /// Gets the wrapper of followers.
         /// </summary>
-        public Followers Followers { get { return new Followers(this); } }
+        public Followers Followers => new Followers(this);
         /// <summary>
         /// Gets the wrapper of friendships.
         /// </summary>
-        public Friendships Friendships { get { return new Friendships(this); } }
+        public Friendships Friendships => new Friendships(this);
         /// <summary>
         /// Gets the wrapper of geo.
         /// </summary>
-        public Geo Geo { get { return new Geo(this); } }
+        public Geo Geo => new Geo(this);
         /// <summary>
         /// Gets the wrapper of help.
         /// </summary>
-        public Help Help { get { return new Help(this); } }
+        public Help Help => new Help(this);
         /// <summary>
         /// Gets the wrapper of lists.
         /// </summary>
-        public Lists Lists { get { return new Lists(this); } }
+        public Lists Lists => new Lists(this);
         /// <summary>
         /// Gets the wrapper of media.
         /// </summary>
-        public Media Media { get { return new Media(this); } }
+        public Media Media => new Media(this);
         /// <summary>
         /// Gets the wrapper of mutes.
         /// </summary>
-        public Mutes Mutes { get { return new Mutes(this); } }
+        public Mutes Mutes => new Mutes(this);
         /// <summary>
         /// Gets the wrapper of search.
         /// </summary>
-        public Search Search { get { return new Search(this); } }
+        public Search Search => new Search(this);
         /// <summary>
         /// Gets the wrapper of saved_searches.
         /// </summary>
-        public SavedSearches SavedSearches { get { return new SavedSearches(this); } }
+        public SavedSearches SavedSearches => new SavedSearches(this);
         /// <summary>
         /// Gets the wrapper of statuses.
         /// </summary>
-        public Statuses Statuses { get { return new Statuses(this); } }
+        public Statuses Statuses => new Statuses(this);
         /// <summary>
         /// Gets the wrapper of trends.
         /// </summary>
-        public Trends Trends { get { return new Trends(this); } }
+        public Trends Trends => new Trends(this);
         /// <summary>
         /// Gets the wrapper of users.
         /// </summary>
-        public Users Users { get { return new Users(this); } }
+        public Users Users => new Users(this);
         /// <summary>
         /// Gets the wrapper of the Streaming API.
         /// </summary>
-        public StreamingApi Streaming { get { return new StreamingApi(this); } }
-
+        public StreamingApi Streaming => new StreamingApi(this);
         #endregion
 
         /// <summary>
@@ -397,20 +396,16 @@ namespace CoreTweet.Core
                     return Request.HttpPostWithMultipartFormData(url, prmArray,
                         CreateAuthorizationHeader(type, url, null), options);
                 }
-                else
-                {
-                    var header = CreateAuthorizationHeader(type, url, prmArray);
-                    return type == MethodType.Get ? Request.HttpGet(url, prmArray, header, options) :
-                        Request.HttpPost(url, prmArray, header, options);
-                }
+
+                var header = CreateAuthorizationHeader(type, url, prmArray);
+                return type == MethodType.Get ? Request.HttpGet(url, prmArray, header, options) :
+                    Request.HttpPost(url, prmArray, header, options);
             }
             catch(WebException ex)
             {
                 var tex = TwitterException.Create(ex);
-                if(tex != null)
-                    throw tex;
-                else
-                    throw;
+                if(tex != null) throw tex;
+                throw;
             }
         }
 #endif

--- a/CoreTweet.Shared/Internal/Utils.cs
+++ b/CoreTweet.Shared/Internal/Utils.cs
@@ -62,15 +62,13 @@ namespace CoreTweet.Core
                 foreach(var f in type.GetFields(BindingFlags.Instance | BindingFlags.Public))
 #endif
                 {
-                    var attr = (TwitterParameterAttribute)f.GetCustomAttributes(true).FirstOrDefault(y => y is TwitterParameterAttribute);
+                    var attr = f.GetCustomAttributes(true).OfType<TwitterParameterAttribute>().FirstOrDefault();
                     var value = f.GetValue(t);
-                    if(attr.DefaultValue == null)
-                        attr.DefaultValue = GetDefaultValue(t.GetType());
-
-                    if(attr != null && value != null && !value.Equals(attr.DefaultValue))
+                    if(attr != null && value != null)
                     {
-                        var name = attr.Name;
-                        d.Add(name ?? f.Name, value);
+                        var defaultValue = attr.DefaultValue ?? GetDefaultValue(t.GetType());
+                        if(!value.Equals(defaultValue))
+                            d.Add(attr.Name ?? f.Name, value);
                     }
                 }
 
@@ -80,15 +78,13 @@ namespace CoreTweet.Core
                 foreach(var p in type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.CanRead))
 #endif
                 {
-                    var attr = (TwitterParameterAttribute)p.GetCustomAttributes(true).FirstOrDefault(y => y is TwitterParameterAttribute);
+                    var attr = p.GetCustomAttributes(true).OfType<TwitterParameterAttribute>().FirstOrDefault();
                     var value = p.GetValue(t, null);
-                    if(attr.DefaultValue == null)
-                        attr.DefaultValue = GetDefaultValue(t.GetType());
-
-                    if(attr != null && value != null && !value.Equals(attr.DefaultValue))
+                    if(attr != null && value != null)
                     {
-                        var name = attr.Name;
-                        d.Add(name ?? p.Name, value);
+                        var defaultValue = attr.DefaultValue ?? GetDefaultValue(t.GetType());
+                        if(!value.Equals(defaultValue))
+                            d.Add(attr.Name ?? p.Name, value);
                     }
                 }
 

--- a/CoreTweet.Shared/Internal/Utils.cs
+++ b/CoreTweet.Shared/Internal/Utils.cs
@@ -20,6 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -28,7 +29,6 @@ using System.Linq.Expressions;
 using System.Net;
 using System.Reflection;
 using System.Text;
-using CoreTweet;
 
 #if !NET35
 using System.Threading;
@@ -43,8 +43,8 @@ namespace CoreTweet.Core
         {
             if(t == null)
                 return new Dictionary<string, object>();
-            if(t is IEnumerable<KeyValuePair<string, object>>)
-                return t as IEnumerable<KeyValuePair<string, object>>;
+            var ie = t as IEnumerable<KeyValuePair<string, object>>;
+            if(ie != null) return ie;
 
 #if WIN_RT
             var type = t.GetType().GetTypeInfo();
@@ -70,7 +70,7 @@ namespace CoreTweet.Core
                     if(attr != null && value != null && !value.Equals(attr.DefaultValue))
                     {
                         var name = attr.Name;
-                        d.Add(name != null ? name : f.Name, value);
+                        d.Add(name ?? f.Name, value);
                     }
                 }
 
@@ -88,7 +88,7 @@ namespace CoreTweet.Core
                     if(attr != null && value != null && !value.Equals(attr.DefaultValue))
                     {
                         var name = attr.Name;
-                        d.Add(name != null ? name : p.Name, value);
+                        d.Add(name ?? p.Name, value);
                     }
                 }
 
@@ -124,7 +124,7 @@ namespace CoreTweet.Core
                             ));
                         }
 #if !NET35
-                        else if(genericTypeDefinition == typeof(Tuple<,>))
+                        if(genericTypeDefinition == typeof(Tuple<,>))
                         {
                             var getItem1 = genericElement.GetProperty("Item1").GetGetMethod();
                             var getItem2 = genericElement.GetProperty("Item2").GetGetMethod();
@@ -306,7 +306,7 @@ namespace CoreTweet.Core
         /// </summary>
         internal static T AccessParameterReservedApi<T>(this TokensBase t, MethodType m, string uri, string reserved, IEnumerable<KeyValuePair<string, object>> parameters)
         {
-            if(parameters == null) throw new ArgumentNullException("parameters");
+            if(parameters == null) throw new ArgumentNullException(nameof(parameters));
             var list = parameters.ToList();
             var kvp = GetReservedParameter(list, reserved);
             list.Remove(kvp);
@@ -315,7 +315,7 @@ namespace CoreTweet.Core
 
         internal static ListedResponse<T> AccessParameterReservedApiArray<T>(this TokensBase t, MethodType m, string uri, string reserved, IEnumerable<KeyValuePair<string, object>> parameters)
         {
-            if(parameters == null) throw new ArgumentNullException("parameters");
+            if(parameters == null) throw new ArgumentNullException(nameof(parameters));
             var list = parameters.ToList();
             var kvp = GetReservedParameter(list, reserved);
             list.Remove(kvp);
@@ -326,7 +326,7 @@ namespace CoreTweet.Core
 #if !NET35
         internal static Task<T> AccessParameterReservedApiAsync<T>(this TokensBase t, MethodType m, string uri, string reserved, IEnumerable<KeyValuePair<string, object>> parameters, CancellationToken cancellationToken)
         {
-            if(parameters == null) throw new ArgumentNullException("parameters");
+            if(parameters == null) throw new ArgumentNullException(nameof(parameters));
             var list = parameters.ToList();
             var kvp = GetReservedParameter(list, reserved);
             list.Remove(kvp);
@@ -335,7 +335,7 @@ namespace CoreTweet.Core
 
         internal static Task<ListedResponse<T>> AccessParameterReservedApiArrayAsync<T>(this TokensBase t, MethodType m, string uri, string reserved, IEnumerable<KeyValuePair<string, object>> parameters, CancellationToken cancellationToken)
         {
-            if(parameters == null) throw new ArgumentNullException("parameters");
+            if(parameters == null) throw new ArgumentNullException(nameof(parameters));
             var list = parameters.ToList();
             var kvp = GetReservedParameter(list, reserved);
             list.Remove(kvp);

--- a/CoreTweet.Shared/OAuth.Async.cs
+++ b/CoreTweet.Shared/OAuth.Async.cs
@@ -24,14 +24,11 @@
 #if !NET35
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Text;
-using Newtonsoft.Json.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreTweet.Core;
+using Newtonsoft.Json.Linq;
 
 namespace CoreTweet
 {
@@ -39,7 +36,7 @@ namespace CoreTweet
     {
         /// <summary>
         /// <para>Generates the authorize URI as an asynchronous operation.</para>
-        /// <para>Then call <see cref="CoreTweet.OAuth.GetTokensAsync"/> after get the pin code.</para>
+        /// <para>Then call <see cref="GetTokensAsync"/> after get the pin code.</para>
         /// </summary>
         /// <param name="consumerKey">The consumer key.</param>
         /// <param name="consumerSecret">The consumer secret.</param>
@@ -88,7 +85,7 @@ namespace CoreTweet
 
         /// <summary>
         /// <para>Gets the OAuth tokens as an asynchronous operation.</para>
-        /// <para>Be sure to call <see cref="CoreTweet.OAuth.AuthorizeAsync"/> before call this method.</para>
+        /// <para>Be sure to call <see cref="AuthorizeAsync"/> before call this method.</para>
         /// </summary>
         /// <param name="session">The OAuth session.</param>
         /// <param name="pin">The pin code.</param>

--- a/CoreTweet.Shared/OAuth.cs
+++ b/CoreTweet.Shared/OAuth.cs
@@ -94,7 +94,7 @@ namespace CoreTweet
 #if !(PCL || WIN_RT || WP)
         /// <summary>
         /// <para>Generates the authorize URI.</para>
-        /// <para>Then call <see cref="CoreTweet.OAuth.GetTokens"/> after get the pin code.</para>
+        /// <para>Then call <see cref="GetTokens"/> after get the pin code.</para>
         /// </summary>
         /// <param name="consumerKey">The Consumer key.</param>
         /// <param name="consumerSecret">The Consumer secret.</param>
@@ -146,7 +146,7 @@ namespace CoreTweet
 
         /// <summary>
         /// <para>Gets the OAuth tokens.</para>
-        /// <para>Be sure to call <see cref="CoreTweet.OAuth.Authorize"/> before call this method.</para>
+        /// <para>Be sure to call <see cref="Authorize"/> before call this method.</para>
         /// </summary>
         /// <param name="session">The OAuth session.</param>
         /// <param name="pin">The pin code.</param>
@@ -239,7 +239,7 @@ namespace CoreTweet
         /// <summary>
         /// Invalidates the OAuth 2 Bearer Token.
         /// </summary>
-        /// <param name="tokens">An instance of <see cref="CoreTweet.OAuth2Token"/>.</param>
+        /// <param name="tokens">An instance of <see cref="OAuth2Token"/>.</param>
         /// <returns>The invalidated token.</returns>
         public static string InvalidateToken(this OAuth2Token tokens)
         {

--- a/CoreTweet.Shared/Objects/Cursored.cs
+++ b/CoreTweet.Shared/Objects/Cursored.cs
@@ -76,24 +76,12 @@ namespace CoreTweet
         /// </summary>
         /// <param name="index">The zero-based index of the element to get or set.</param>
         /// <returns>The element at the specified index.</returns>
-        public T this[int index]
-        {
-            get
-            {
-                return this.Result[index];
-            }
-        }
+        public T this[int index] => this.Result[index];
 
         /// <summary>
         /// Gets the number of elements actually contained in the <see cref="Cursored&lt;T&gt;"/>.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return this.Result.Length;
-            }
-        }
+        public int Count => this.Result.Length;
 
         /// <summary>
         /// Gets or sets the rate limit of the response.

--- a/CoreTweet.Shared/Objects/Entities.cs
+++ b/CoreTweet.Shared/Objects/Entities.cs
@@ -157,7 +157,7 @@ namespace CoreTweet
     }
 
     /// <summary>
-    /// Represents the size of the <see cref="CoreTweet.MediaSizes"/>.
+    /// Represents the size of the <see cref="MediaSizes"/>.
     /// </summary>
     public class MediaSize : CoreBase
     {
@@ -274,7 +274,7 @@ namespace CoreTweet
         public string DisplayUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the expanded version of <see cref="CoreTweet.UrlEntity.DisplayUrl"/>.
+        /// Gets or sets the expanded version of <see cref="DisplayUrl"/>.
         /// </summary>
         // Note that Twitter accepts invalid URLs, for example, "http://..com"
         [JsonProperty("expanded_url")]

--- a/CoreTweet.Shared/Objects/Helps.cs
+++ b/CoreTweet.Shared/Objects/Helps.cs
@@ -123,13 +123,7 @@ namespace CoreTweet
         /// <summary>
         /// Gets or sets the value of response.
         /// </summary>
-        public string Value
-        {
-            get
-            {
-                return this.privacy ?? this.tos;
-            }
-        }
+        public string Value => this.privacy ?? this.tos;
 
         /// <summary>
         /// Gets or sets the rate limit of the response.

--- a/CoreTweet.Shared/Objects/List.cs
+++ b/CoreTweet.Shared/Objects/List.cs
@@ -36,27 +36,27 @@ namespace CoreTweet
         /// Gets or sets the string that becomes unique representation by combining an owner_id or owner_screen_name.
         /// </summary>
         [JsonProperty("slug")]
-        public string Slug{ get; set; }
+        public string Slug { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the List.
         /// </summary>
         [JsonProperty("name")]
-        public string Name{ get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the when the List was created.
         /// </summary>
         [JsonProperty("created_at")]
         [JsonConverter(typeof(DateTimeOffsetConverter))]
-        public DateTimeOffset CreatedAt{ get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
 
         /// <summary>
         /// <para>Gets or sets the URL of the List.</para>
         /// <para>Usage: string.Format("https://twitter.com{0}", uri);</para>
         /// </summary>
         [JsonProperty("uri")]
-        public string Uri{ get; set; }
+        public string Uri { get; set; }
 
         /// <summary>
         /// Gets or sets the number of users following the List.
@@ -68,43 +68,43 @@ namespace CoreTweet
         /// Gets or sets the number of members in the List.
         /// </summary>
         [JsonProperty("member_count")]
-        public int MemberCount{ get; set; }
+        public int MemberCount { get; set; }
 
         /// <summary>
         /// Gets or sets the integer representation of the unique identifier for the List.
         /// </summary>
         [JsonProperty("id")]
-        public long Id{ get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Gets or sets a value that indicates whether the List has been published by the owner.
         /// </summary>
         [JsonProperty("mode")]
-        public string Mode{ get; set; }
+        public string Mode { get; set; }
 
         /// <summary>
         /// Gets or sets the full name of the List.
         /// </summary>
         [JsonProperty("full_name")]
-        public string FullName{ get; set; }
+        public string FullName { get; set; }
 
         /// <summary>
         /// Gets or sets the user-defined string describes the List. Nullable.
         /// </summary>
         [JsonProperty("description")]
-        public string Description{ get; set; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Gets or sets the user of the owner of the List.
         /// </summary>
         [JsonProperty("user")]
-        public User User{ get; set; }
+        public User User { get; set; }
 
         /// <summary>
         /// Gets or sets a value that determines if the List has been followed by the authenticating user.
         /// </summary>
         [JsonProperty("following")]
-        public bool IsFollowing{ get; set; }
+        public bool IsFollowing { get; set; }
 
         /// <summary>
         /// Returns the ID of this instance.

--- a/CoreTweet.Shared/Objects/Places.cs
+++ b/CoreTweet.Shared/Objects/Places.cs
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using CoreTweet.Core;
@@ -134,7 +135,7 @@ namespace CoreTweet
 
     /// <summary>
     /// <para>Represents a bounding box.</para>
-    /// <para>This class can be converted to a JSON with <see cref="Newtonsoft.Json.JsonConvert.SerializeObject(object)"/>.</para>
+    /// <para>This class can be converted to a JSON with <see cref="JsonConvert.SerializeObject(object)"/>.</para>
     /// </summary>
     [JsonObject]
     public class BoundingBox : CoreBase, IEnumerable<Coordinates>
@@ -160,9 +161,9 @@ namespace CoreTweet
         [JsonProperty("type")]
         public string Type { get; set; }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetCoordinates().ToArray().GetEnumerator();
+            return GetCoordinates().GetEnumerator();
         }
 
         /// <summary>
@@ -183,7 +184,7 @@ namespace CoreTweet
         {
             get
             {
-                return GetCoordinates().ToArray()[index];
+                return GetCoordinates().ElementAt(index);
             }
             set
             {
@@ -222,19 +223,13 @@ namespace CoreTweet
         /// </summary>
         public string Json { get; set; }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return Places.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => this.Places.GetEnumerator();
 
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>An IEnumerator object that can be used to iterate through the collection.</returns>
-        public IEnumerator<Place> GetEnumerator()
-        {
-            return (Places as IEnumerable<Place>).GetEnumerator();
-        }
+        public IEnumerator<Place> GetEnumerator() => (this.Places as IEnumerable<Place>).GetEnumerator();
     }
 
     /// <summary>
@@ -269,10 +264,7 @@ namespace CoreTweet
         [JsonProperty("trends")]
         public Trend[] Trends { get; set; }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return Trends.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => Trends.GetEnumerator();
 
         /// <summary>
         /// Returns an enumerator that iterates through a collection.

--- a/CoreTweet.Shared/Objects/SearchQuery.cs
+++ b/CoreTweet.Shared/Objects/SearchQuery.cs
@@ -37,25 +37,25 @@ namespace CoreTweet
         /// </summary>
         [JsonProperty("created_at")]
         [JsonConverter(typeof(DateTimeOffsetConverter))]
-        public DateTimeOffset CreatedAt{ get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the saved search.
         /// </summary>
         [JsonProperty("id")]
-        public long? Id{ get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the saved search.
         /// </summary>
         [JsonProperty("name")]
-        public string Name{ get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the query of the saved search.
         /// </summary>
         [JsonProperty("query")]
-        public string Query{ get; set; }
+        public string Query { get; set; }
 
         /// <summary>
         /// Returns the ID of this instance.

--- a/CoreTweet.Shared/Objects/Status.cs
+++ b/CoreTweet.Shared/Objects/Status.cs
@@ -75,9 +75,7 @@ namespace CoreTweet
         {
             get
             {
-                return currentUserRetweetDic != null
-                    ? (long?)currentUserRetweetDic["id"]
-                    : null;
+                return (long?)currentUserRetweetDic?["id"];
             }
             set
             {
@@ -340,24 +338,12 @@ namespace CoreTweet
         /// <summary>
         /// Gets or sets the longtitude of the location.
         /// </summary>
-        public double Longtitude
-        {
-            get
-            {
-                return _coordinates[0];
-            }
-        }
+        public double Longtitude => this._coordinates[0];
 
         /// <summary>
         /// Gets or sets the latitude of the location.
         /// </summary>
-        public double Latitude
-        {
-            get
-            {
-                return _coordinates[1];
-            }
-        }
+        public double Latitude => this._coordinates[1];
 
         [JsonProperty("coordinates")]
         double[] _coordinates { get; set; }
@@ -498,33 +484,18 @@ namespace CoreTweet
         /// </summary>
         /// <param name="index">The zero-based index of the element to get or set.</param>
         /// <returns>The element at the specified index.</returns>
-        public Status this[int index]
-        {
-            get
-            {
-                return this.statuses[index];
-            }
-        }
+        public Status this[int index] => this.statuses[index];
 
         /// <summary>
         /// Gets the number of elements actually contained in the <see cref="SearchResult"/>.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return this.statuses.Count;
-            }
-        }
+        public int Count => this.statuses.Count;
 
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>An IEnumerator object that can be used to iterate through the collection.</returns>
-        public IEnumerator<Status> GetEnumerator()
-        {
-            return this.statuses.GetEnumerator();
-        }
+        public IEnumerator<Status> GetEnumerator() => this.statuses.GetEnumerator();
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {

--- a/CoreTweet.Shared/Objects/Tokens.cs
+++ b/CoreTweet.Shared/Objects/Tokens.cs
@@ -21,7 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using CoreTweet.Core;
@@ -51,12 +50,12 @@ namespace CoreTweet
         public string ScreenName { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CoreTweet.Tokens"/> class.
+        /// Initializes a new instance of the <see cref="Tokens"/> class.
         /// </summary>
         public Tokens() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CoreTweet.Tokens"/> class with a specified token.
+        /// Initializes a new instance of the <see cref="Tokens"/> class with a specified token.
         /// </summary>
         /// <param name="e">The token.</param>
         public Tokens(Tokens e) : this()
@@ -84,14 +83,14 @@ namespace CoreTweet
                 : prms;
             var sgn = Request.GenerateSignature(this, type == MethodType.Get ? "GET" : "POST", url, sigPrms);
             prms.Add("oauth_signature", sgn);
-            return "OAuth " + prms.Select(p => String.Format(@"{0}=""{1}""", Request.UrlEncode(p.Key), Request.UrlEncode(p.Value))).JoinToString(",");
+            return "OAuth " + prms.Select(p => string.Format(@"{0}=""{1}""", Request.UrlEncode(p.Key), Request.UrlEncode(p.Value))).JoinToString(",");
         }
 
         /// <summary>
-        /// Returns a <see cref="System.String"/> that represents the current <see cref="CoreTweet.Tokens"/>.
+        /// Returns a <see cref="string"/> that represents the current <see cref="Tokens"/>.
         /// </summary>
         /// <returns>
-        /// A <see cref="System.String"/> that represents the current <see cref="CoreTweet.Tokens"/>.
+        /// A <see cref="string"/> that represents the current <see cref="Tokens"/>.
         /// </returns>
         public override string ToString()
         {

--- a/CoreTweet.Shared/Objects/User.cs
+++ b/CoreTweet.Shared/Objects/User.cs
@@ -248,8 +248,8 @@ namespace CoreTweet
 
         /// <summary>
         /// <para>Gets or sets the screen name, handle, or alias that this user identifies themselves with.</para>
-        /// <para><see cref="CoreTweet.User.ScreenName"/> are unique but subject to be changed.</para>
-        /// <para>Use <see cref="CoreTweet.User.Id"/> as a user identifier whenever possible.</para>
+        /// <para><see cref="ScreenName"/> are unique but subject to be changed.</para>
+        /// <para>Use <see cref="Id"/> as a user identifier whenever possible.</para>
         /// <para>Typically a maximum of 15 characters long, but some historical accounts may exist with longer names.</para>
         /// </summary>
         [JsonProperty("screen_name")]
@@ -510,13 +510,13 @@ namespace CoreTweet
         /// Gets or sets the slug of the category.
         /// </summary>
         [JsonProperty("slug")]
-        public string Slug{ get; set; }
+        public string Slug { get; set; }
 
         /// <summary>
         /// Gets or sets the size of the category.
         /// </summary>
         [JsonProperty("size")]
-        public int Size{ get; set; }
+        public int Size { get; set; }
 
         /// <summary>
         /// Gets or sets the users in this category.
@@ -562,14 +562,12 @@ namespace CoreTweet
         /// Gets or sets the size for Apple iPad.
         /// </summary>
         [JsonProperty("ipad")]
-        // ReSharper disable once InconsistentNaming
         public ProfileBannerSize IPad { get; set; }
 
         /// <summary>
         /// Gets or sets the size for Apple iPad with high resolution.
         /// </summary>
         [JsonProperty("ipad_retina")]
-        // ReSharper disable once InconsistentNaming
         public ProfileBannerSize IPadRetina { get; set; }
 
         /// <summary>
@@ -625,13 +623,13 @@ namespace CoreTweet
     public class UserEntities : CoreBase
     {
         /// <summary>
-        /// Gets or sets the entities for <see cref="CoreTweet.User.Url"/> field.
+        /// Gets or sets the entities for <see cref="User.Url"/> field.
         /// </summary>
         [JsonProperty("url")]
         public Entities Url { get; set; }
 
         /// <summary>
-        /// Gets or sets the entities for <see cref="CoreTweet.User.Description"/> field.
+        /// Gets or sets the entities for <see cref="User.Description"/> field.
         /// </summary>
         [JsonProperty("description")]
         public Entities Description { get; set; }

--- a/CoreTweet.Shared/Request.Async.cs
+++ b/CoreTweet.Shared/Request.Async.cs
@@ -125,14 +125,11 @@ namespace CoreTweet
         {
             if(disposing)
             {
-                if(this.Source != null)
-                {
 #if PCL || WIN_RT
-                    this.Source.Dispose();
+                this.Source?.Dispose();
 #else
-                    this.Source.Close();
+                this.Source?.Close();
 #endif
-                }
                 this.Source = null;
                 this.Headers = null;
             }
@@ -178,8 +175,7 @@ namespace CoreTweet
                 req.Headers.Connection.Clear();
                 req.Headers.Connection.Add(new HttpConnectionOptionHeaderValue("close"));
             }
-            if(options.BeforeRequestAction != null)
-                options.BeforeRequestAction(req);
+            options.BeforeRequestAction?.Invoke(req);
             var cancellation = new CancellationTokenSource();
             var handler = new HttpBaseProtocolFilter();
             handler.AutomaticDecompression = options.UseCompression;
@@ -233,7 +229,6 @@ namespace CoreTweet
 
             try
             {
-                if(prm == null) prm = new Dictionary<string, object>();
                 var req = (HttpWebRequest)WebRequest.Create(reqUrl);
 
                 var reg = cancellationToken.Register(() =>
@@ -253,7 +248,7 @@ namespace CoreTweet
                 req.Headers[HttpRequestHeader.Authorization] = authorizationHeader;
 #if !PCL
                 req.UserAgent = options.UserAgent;
-                if(options.BeforeRequestAction != null) options.BeforeRequestAction(req);
+                options.BeforeRequestAction?.Invoke(req);
 #endif
 
                 var timeoutCancellation = new CancellationTokenSource();
@@ -351,7 +346,7 @@ namespace CoreTweet
 #endif
 #if !PCL
                 req.UserAgent = options.UserAgent;
-                if (options.BeforeRequestAction != null) options.BeforeRequestAction(req);
+                options.BeforeRequestAction?.Invoke(req);
 #endif
 
                 var timeoutCancellation = new CancellationTokenSource();
@@ -449,15 +444,14 @@ namespace CoreTweet
                     valueInputStream = valueStream.AsInputStream();
                 if(valueBytes != null)
                 {
-                    var valueByteArray = valueBytes as byte[];
-                    if(valueByteArray == null) valueByteArray = valueBytes.ToArray();
+                    var valueByteArray = valueBytes as byte[] ?? valueBytes.ToArray();
                     valueBuffer = valueByteArray.AsBuffer();
                 }
 
                 if(valueInputStream != null)
-                    content.Add(new HttpStreamContent(valueInputStream), x.Key, valueStorageItem != null ? valueStorageItem.Name : "file");
+                    content.Add(new HttpStreamContent(valueInputStream), x.Key, valueStorageItem?.Name ?? "file");
                 else if(valueBuffer != null)
-                    content.Add(new HttpBufferContent(valueBuffer), x.Key, valueStorageItem != null ? valueStorageItem.Name : "file");
+                    content.Add(new HttpBufferContent(valueBuffer), x.Key, valueStorageItem?.Name ?? "file");
                 else
                     content.Add(new HttpStringContent(x.Value.ToString()), x.Key);
             }
@@ -500,7 +494,7 @@ namespace CoreTweet
                 req.ContentType = "multipart/form-data;boundary=" + boundary;
                 req.Headers[HttpRequestHeader.Authorization] = authorizationHeader;
 #if !PCL
-                if(options.BeforeRequestAction != null) options.BeforeRequestAction(req);
+                options.BeforeRequestAction?.Invoke(req);
 #endif
 
                 var timeoutCancellation = new CancellationTokenSource();

--- a/CoreTweet.Shared/Request.cs
+++ b/CoreTweet.Shared/Request.cs
@@ -165,7 +165,7 @@ namespace CoreTweet
                 req.AutomaticDecompression = CompressionType;
             if (options.DisableKeepAlive)
                 req.KeepAlive = false;
-            if(options.BeforeRequestAction != null) options.BeforeRequestAction(req);
+            options.BeforeRequestAction?.Invoke(req);
             return (HttpWebResponse)req.GetResponse();
         }
 
@@ -188,7 +188,7 @@ namespace CoreTweet
                 req.AutomaticDecompression = CompressionType;
             if (options.DisableKeepAlive)
                 req.KeepAlive = false;
-            if(options.BeforeRequestAction != null) options.BeforeRequestAction(req);
+            options.BeforeRequestAction?.Invoke(req);
             using(var reqstr = req.GetRequestStream())
                 reqstr.Write(data, 0, data.Length);
             return (HttpWebResponse)req.GetResponse();
@@ -212,7 +212,7 @@ namespace CoreTweet
                 req.AutomaticDecompression = CompressionType;
             if (options.DisableKeepAlive)
                 req.KeepAlive = false;
-            if (options.BeforeRequestAction != null) options.BeforeRequestAction(req);
+            options.BeforeRequestAction?.Invoke(req);
             using(var reqstr = req.GetRequestStream())
                 WriteMultipartFormData(reqstr, boundary, prm);
             return (HttpWebResponse)req.GetResponse();

--- a/CoreTweet.Shared/Rest/Lists.cs
+++ b/CoreTweet.Shared/Rest/Lists.cs
@@ -28,11 +28,11 @@ namespace CoreTweet.Rest
         /// <summary>
         /// Gets the wrapper of lists/members
         /// </summary>
-        public ListsMembers Members { get { return new ListsMembers(this.Tokens); } }
+        public ListsMembers Members => new ListsMembers(this.Tokens);
 
         /// <summary>
         /// Gets the wrapper of lists/subscribers
         /// </summary>
-        public ListsSubscribers Subscribers { get { return new ListsSubscribers(this.Tokens); } }
+        public ListsSubscribers Subscribers => new ListsSubscribers(this.Tokens);
     }
 }

--- a/CoreTweet.Shared/Rest/Media.Async.cs
+++ b/CoreTweet.Shared/Rest/Media.Async.cs
@@ -109,10 +109,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public Task<MediaUploadResult> UploadAsync(Stream media, IEnumerable<long> additional_owners = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (media == null) throw new ArgumentNullException("media");
+            if (media == null) throw new ArgumentNullException(nameof(media));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media", media);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media), media);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadAsyncImpl(parameters, cancellationToken);
         }
 
@@ -125,10 +125,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public Task<MediaUploadResult> UploadAsync(IEnumerable<byte> media, IEnumerable<long> additional_owners = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (media == null) throw new ArgumentNullException("media");
+            if (media == null) throw new ArgumentNullException(nameof(media));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media", media);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media), media);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadAsyncImpl(parameters, cancellationToken);
         }
 
@@ -142,10 +142,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public Task<MediaUploadResult> UploadAsync(FileInfo media, IEnumerable<long> additional_owners = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (media == null) throw new ArgumentNullException("media");
+            if (media == null) throw new ArgumentNullException(nameof(media));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media", media);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media), media);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadAsyncImpl(parameters, cancellationToken);
         }
 #endif
@@ -159,10 +159,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public Task<MediaUploadResult> UploadAsync(string media_data, IEnumerable<long> additional_owners = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (media_data == null) throw new ArgumentNullException("media_data");
+            if (media_data == null) throw new ArgumentNullException(nameof(media_data));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media_data", media_data);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media_data), media_data);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadAsyncImpl(parameters, cancellationToken);
         }
 
@@ -340,7 +340,7 @@ namespace CoreTweet.Rest
         public Task<MediaUploadResult> UploadChunkedAsync(Stream media, int totalBytes, UploadMediaType mediaType, IEnumerable<long> additional_owners = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var parameters = new Dictionary<string, object>();
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadChunkedAsyncImpl(media, totalBytes, mediaType, parameters, cancellationToken);
         }
 

--- a/CoreTweet.Shared/Rest/Media.cs
+++ b/CoreTweet.Shared/Rest/Media.cs
@@ -113,10 +113,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public MediaUploadResult Upload(Stream media, IEnumerable<long> additional_owners = null)
         {
-            if (media == null) throw new ArgumentNullException("media");
+            if (media == null) throw new ArgumentNullException(nameof(media));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media", media);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media), media);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadImpl(parameters);
         }
 
@@ -128,10 +128,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public MediaUploadResult Upload(IEnumerable<byte> media, IEnumerable<long> additional_owners = null)
         {
-            if (media == null) throw new ArgumentNullException("media");
+            if (media == null) throw new ArgumentNullException(nameof(media));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media", media);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media), media);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadImpl(parameters);
         }
 
@@ -144,10 +144,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public MediaUploadResult Upload(FileInfo media, IEnumerable<long> additional_owners = null)
         {
-            if (media == null) throw new ArgumentNullException("media");
+            if (media == null) throw new ArgumentNullException(nameof(media));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media", media);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media), media);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadImpl(parameters);
         }
 #endif
@@ -160,10 +160,10 @@ namespace CoreTweet.Rest
         /// <returns>The result for the uploaded media.</returns>
         public MediaUploadResult Upload(string media_data, IEnumerable<long> additional_owners = null)
         {
-            if (media_data == null) throw new ArgumentNullException("media_data");
+            if (media_data == null) throw new ArgumentNullException(nameof(media_data));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("media_data", media_data);
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            parameters.Add(nameof(media_data), media_data);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadImpl(parameters);
         }
 
@@ -275,7 +275,7 @@ namespace CoreTweet.Rest
         public MediaUploadResult UploadChunked(Stream media, int totalBytes, UploadMediaType mediaType, IEnumerable<long> additional_owners = null)
         {
             var parameters = new Dictionary<string, object>();
-            if (additional_owners != null) parameters.Add("additional_owners", additional_owners);
+            if (additional_owners != null) parameters.Add(nameof(additional_owners), additional_owners);
             return this.UploadChunkedImpl(media, totalBytes, mediaType, parameters);
         }
 

--- a/CoreTweet.Shared/Rest/Mutes.cs
+++ b/CoreTweet.Shared/Rest/Mutes.cs
@@ -21,9 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using CoreTweet.Core;
 
 namespace CoreTweet.Rest
@@ -38,6 +35,6 @@ namespace CoreTweet.Rest
         /// <summary>
         /// Gets the wrapper of mutes/users.
         /// </summary>
-        public MutesUsers Users { get { return new MutesUsers(this.Tokens); } }
+        public MutesUsers Users => new MutesUsers(this.Tokens);
     }
 }

--- a/CoreTweet.Shared/Streaming/Messages.cs
+++ b/CoreTweet.Shared/Streaming/Messages.cs
@@ -263,7 +263,7 @@ namespace CoreTweet.Streaming
         /// <summary>
         /// Gets the type of the message.
         /// </summary>
-        public MessageType Type { get { return GetMessageType(); } }
+        public MessageType Type => this.GetMessageType();
 
         /// <summary>
         /// Gets or sets the raw JSON.
@@ -321,11 +321,11 @@ namespace CoreTweet.Streaming
             JToken jt;
             if(jo.TryGetValue("disconnect", out jt))
                 return jt.ToObject<DisconnectMessage>();
-            else if(jo.TryGetValue("warning", out jt))
+            if(jo.TryGetValue("warning", out jt))
                 return jt.ToObject<WarningMessage>();
-            else if(jo.TryGetValue("control", out jt))
+            if(jo.TryGetValue("control", out jt))
                 return jt.ToObject<ControlMessage>();
-            else if(jo.TryGetValue("delete", out jt))
+            if(jo.TryGetValue("delete", out jt))
             {
                 JToken status;
                 DeleteMessage id;
@@ -344,43 +344,43 @@ namespace CoreTweet.Streaming
                     id.Timestamp = InternalUtils.GetUnixTimeMs(long.Parse((string)timestamp));
                 return id;
             }
-            else if(jo.TryGetValue("scrub_geo", out jt))
+            if(jo.TryGetValue("scrub_geo", out jt))
             {
                 return jt.ToObject<ScrubGeoMessage>();
             }
-            else if(jo.TryGetValue("limit", out jt))
+            if(jo.TryGetValue("limit", out jt))
             {
                 return jt.ToObject<LimitMessage>();
             }
-            else if(jo.TryGetValue("status_withheld", out jt))
+            if(jo.TryGetValue("status_withheld", out jt))
             {
                 return jt.ToObject<StatusWithheldMessage>();
             }
-            else if(jo.TryGetValue("user_withheld", out jt))
+            if(jo.TryGetValue("user_withheld", out jt))
             {
                 return jt.ToObject<UserWithheldMessage>();
             }
-            else if(jo.TryGetValue("user_delete", out jt))
+            if(jo.TryGetValue("user_delete", out jt))
             {
                 var m = jt.ToObject<UserMessage>();
                 m.messageType = MessageType.UserDelete;
                 return m;
             }
-            else if(jo.TryGetValue("user_undelete", out jt))
+            if(jo.TryGetValue("user_undelete", out jt))
             {
                 var m = jt.ToObject<UserMessage>();
                 m.messageType = MessageType.UserUndelete;
                 return m;
             }
-            else if(jo.TryGetValue("user_suspend", out jt))
+            if(jo.TryGetValue("user_suspend", out jt))
             {
                 // user_suspend doesn't have 'timestamp_ms' field
                 var m = jt.ToObject<UserMessage>();
                 m.messageType = MessageType.UserSuspend;
                 return m;
             }
-            else
-                throw new ParsingException("on streaming, cannot parse the json: unsupported type", jo.ToString(Formatting.Indented), null);
+
+            throw new ParsingException("on streaming, cannot parse the json: unsupported type", jo.ToString(Formatting.Indented), null);
         }
     }
 
@@ -826,7 +826,7 @@ namespace CoreTweet.Streaming
         /// <summary>
         /// Gets or sets the target List.
         /// </summary>
-        public CoreTweet.List TargetList { get; set; }
+        public List TargetList { get; set; }
 
         /// <summary>
         /// Gets or sets the target access token.
@@ -874,7 +874,7 @@ namespace CoreTweet.Streaming
                     e.TargetStatus = j["target_object"].ToObject<Status>();
                     break;
                 case EventTargetType.List:
-                    e.TargetList = j["target_object"].ToObject<CoreTweet.List>();
+                    e.TargetList = j["target_object"].ToObject<List>();
                     break;
                 case EventTargetType.AccessRevocation:
                     e.TargetToken = j["target_object"].ToObject<AccessRevocation>();

--- a/CoreTweet.Shared/Streaming/Stream.cs
+++ b/CoreTweet.Shared/Streaming/Stream.cs
@@ -106,7 +106,7 @@ namespace CoreTweet.Streaming
             return InternalUtils.GetUrl(options, baseUrl, true, apiName);
         }
 
-        internal MethodType GetMethodType(StreamingType type)
+        internal static MethodType GetMethodType(StreamingType type)
         {
             return type == StreamingType.Filter ? MethodType.Post : MethodType.Get;
         }
@@ -166,7 +166,7 @@ namespace CoreTweet.Streaming
             if(parameters == null)
                 parameters = new StreamingParameters();
 
-            return this.Tokens.SendStreamingRequestAsync(this.GetMethodType(type), this.GetUrl(type), parameters.Parameters, cancellationToken)
+            return this.Tokens.SendStreamingRequestAsync(GetMethodType(type), this.GetUrl(type), parameters.Parameters, cancellationToken)
                 .ContinueWith(t =>
                 {
                     if(t.IsFaulted)
@@ -190,7 +190,7 @@ namespace CoreTweet.Streaming
         private IEnumerable<StreamingMessage> AccessStreamingApiImpl(StreamingType type, IEnumerable<KeyValuePair<string, object>> parameters)
         {
             return EnumerateMessages(
-                this.Tokens.SendStreamingRequest(this.GetMethodType(type), this.GetUrl(type), parameters).GetResponseStream()
+                this.Tokens.SendStreamingRequest(GetMethodType(type), this.GetUrl(type), parameters).GetResponseStream()
             );
         }
 
@@ -272,11 +272,11 @@ namespace CoreTweet.Streaming
         public IEnumerable<StreamingMessage> User(bool? stall_warnings = null, string with = null, string replies = null, string track = null, IEnumerable<double> locations = null)
         {
             var parameters = new Dictionary<string, object>();
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
-            if (with != null) parameters.Add("with", with);
-            if (replies != null) parameters.Add("replies", replies);
-            if (track != null) parameters.Add("track", track);
-            if (locations != null) parameters.Add("locations", locations);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
+            if (with != null) parameters.Add(nameof(with), with);
+            if (replies != null) parameters.Add(nameof(replies), replies);
+            if (track != null) parameters.Add(nameof(track), track);
+            if (locations != null) parameters.Add(nameof(locations), locations);
             return this.AccessStreamingApiImpl(StreamingType.User, parameters);
         }
 
@@ -338,12 +338,12 @@ namespace CoreTweet.Streaming
         /// <returns>The stream messages.</returns>
         public IEnumerable<StreamingMessage> Site(IEnumerable<long> follow, bool? stall_warnings = null, string with = null, string replies = null)
         {
-            if (follow == null) throw new ArgumentNullException("follow");
+            if (follow == null) throw new ArgumentNullException(nameof(follow));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("follow", follow);
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
-            if (with != null) parameters.Add("with", with);
-            if (replies != null) parameters.Add("replies", replies);
+            parameters.Add(nameof(follow), follow);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
+            if (with != null) parameters.Add(nameof(with), with);
+            if (replies != null) parameters.Add(nameof(replies), replies);
             return this.AccessStreamingApiImpl(StreamingType.Site, parameters);
         }
 
@@ -416,10 +416,10 @@ namespace CoreTweet.Streaming
             if (follow == null && track == null && locations == null)
                 throw new ArgumentException("At least one predicate parameter (follow, locations, or track) must be specified.");
             var parameters = new Dictionary<string, object>();
-            if (follow != null) parameters.Add("follow", follow);
-            if (track != null) parameters.Add("track", track);
-            if (locations != null) parameters.Add("locations", locations);
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
+            if (follow != null) parameters.Add(nameof(follow), follow);
+            if (track != null) parameters.Add(nameof(track), track);
+            if (locations != null) parameters.Add(nameof(locations), locations);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
             return this.AccessStreamingApiImpl(StreamingType.Filter, parameters);
         }
 
@@ -474,7 +474,7 @@ namespace CoreTweet.Streaming
         public IEnumerable<StreamingMessage> Sample(bool? stall_warnings = null)
         {
             var parameters = new Dictionary<string, object>();
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
             return this.AccessStreamingApiImpl(StreamingType.Sample, parameters);
         }
 
@@ -533,8 +533,8 @@ namespace CoreTweet.Streaming
         public IEnumerable<StreamingMessage> Firehose(int? count = null, bool? stall_warnings = null)
         {
             var parameters = new Dictionary<string, object>();
-            if (count != null) parameters.Add("count", count);
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
+            if (count != null) parameters.Add(nameof(count), count);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
             return this.AccessStreamingApiImpl(StreamingType.Firehose, parameters);
         }
 #endif

--- a/CoreTweet.Streaming.Reactive/Stream.cs
+++ b/CoreTweet.Streaming.Reactive/Stream.cs
@@ -29,6 +29,7 @@ using System.Linq.Expressions;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using CoreTweet.Core;
+using static CoreTweet.Streaming.StreamingApi;
 
 namespace CoreTweet.Streaming.Reactive
 {
@@ -57,7 +58,7 @@ namespace CoreTweet.Streaming.Reactive
         {
             return Observable.Create<StreamingMessage>((observer, cancel) =>
             {
-                return e.IncludedTokens.SendStreamingRequestAsync(e.GetMethodType(type), e.GetUrl(type), parameters, cancel)
+                return e.IncludedTokens.SendStreamingRequestAsync(GetMethodType(type), e.GetUrl(type), parameters, cancel)
                     .ContinueWith(task =>
                     {
                         if(task.IsFaulted)
@@ -74,7 +75,7 @@ namespace CoreTweet.Streaming.Reactive
                         try
                         {
                             using (var reader = new StreamReader(task.Result))
-                            using (var reg = cancel.Register(() => reader.Dispose()))
+                            using (cancel.Register(() => reader.Dispose()))
                             {
                                 foreach (var s in reader.EnumerateLines().Where(x => !string.IsNullOrEmpty(x)))
                                 {
@@ -179,11 +180,11 @@ namespace CoreTweet.Streaming.Reactive
         public static IObservable<StreamingMessage> UserAsObservable(this StreamingApi e, bool? stall_warnings = null, string with = null, string replies = null, string track = null, IEnumerable<double> locations = null)
         {
             var parameters = new Dictionary<string, object>();
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
-            if (with != null) parameters.Add("with", with);
-            if (replies != null) parameters.Add("replies", replies);
-            if (track != null) parameters.Add("track", track);
-            if (locations != null) parameters.Add("locations", locations);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
+            if (with != null) parameters.Add(nameof(with), with);
+            if (replies != null) parameters.Add(nameof(replies), replies);
+            if (track != null) parameters.Add(nameof(track), track);
+            if (locations != null) parameters.Add(nameof(locations), locations);
             return AccessStreamingApiAsObservableImpl(e, StreamingType.User, parameters);
         }
 
@@ -249,12 +250,12 @@ namespace CoreTweet.Streaming.Reactive
         /// <returns>The stream messages.</returns>
         public static IObservable<StreamingMessage> SiteAsObservable(this StreamingApi e, IEnumerable<long> follow, bool? stall_warnings = null, string with = null, string replies = null)
         {
-            if (follow == null) throw new ArgumentNullException("follow");
+            if (follow == null) throw new ArgumentNullException(nameof(follow));
             var parameters = new Dictionary<string, object>();
-            parameters.Add("follow", follow);
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
-            if (with != null) parameters.Add("with", with);
-            if (replies != null) parameters.Add("replies", replies);
+            parameters.Add(nameof(follow), follow);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
+            if (with != null) parameters.Add(nameof(with), with);
+            if (replies != null) parameters.Add(nameof(replies), replies);
             return AccessStreamingApiAsObservableImpl(e, StreamingType.Site, parameters);
         }
 
@@ -331,10 +332,10 @@ namespace CoreTweet.Streaming.Reactive
             if (follow == null && track == null && locations == null)
                 throw new ArgumentException("At least one predicate parameter (follow, locations, or track) must be specified.");
             var parameters = new Dictionary<string, object>();
-            if (follow != null) parameters.Add("follow", follow);
-            if (track != null) parameters.Add("track", track);
-            if (locations != null) parameters.Add("locations", locations);
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
+            if (follow != null) parameters.Add(nameof(follow), follow);
+            if (track != null) parameters.Add(nameof(track), track);
+            if (locations != null) parameters.Add(nameof(locations), locations);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
             return AccessStreamingApiAsObservableImpl(e, StreamingType.Filter, parameters);
         }
 
@@ -393,7 +394,7 @@ namespace CoreTweet.Streaming.Reactive
         public static IObservable<StreamingMessage> SampleAsObservable(this StreamingApi e, bool? stall_warnings = null)
         {
             var parameters = new Dictionary<string, object>();
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
             return AccessStreamingApiAsObservableImpl(e, StreamingType.Sample, parameters);
         }
 
@@ -456,8 +457,8 @@ namespace CoreTweet.Streaming.Reactive
         public static IObservable<StreamingMessage> FirehoseAsObservable(this StreamingApi e, int? count = null, bool? stall_warnings = null)
         {
             var parameters = new Dictionary<string, object>();
-            if (count != null) parameters.Add("count", count);
-            if (stall_warnings != null) parameters.Add("stall_warnings", stall_warnings);
+            if (count != null) parameters.Add(nameof(count), count);
+            if (stall_warnings != null) parameters.Add(nameof(stall_warnings), stall_warnings);
             return AccessStreamingApiAsObservableImpl(e, StreamingType.Firehose, parameters);
         }
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: 0.5.2.{build}
 
+os: Visual Studio 2015
+
 install:
   - cinst -y doxygen.portable
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: 0.5.2.{build}
 os: Visual Studio 2015
 
 install:
+  - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
   - cinst -y doxygen.portable
 
 assembly_info:


### PR DESCRIPTION
* C#6.0 の機能をつかったコードの簡略化（プロパティで => をつかう, ?. を使う）
* XML コメントの名前空間省略
* Travis CI の新環境対応
* TwitterParametersAttribute 判断時に NullReferenceException が出るのを修正

CoreTweet-All.sln が v14 になったけど AppVeyor で死ぬので戻さないように！