### PR TITLE
Fix UserMentionEntity.Id to be nullable

### DIFF
--- a/CoreTweet.Shared/Objects/Entities.cs
+++ b/CoreTweet.Shared/Objects/Entities.cs
@@ -293,10 +293,11 @@ namespace CoreTweet
     public class UserMentionEntity : Entity
     {
         /// <summary>
+        /// Nullable.
         /// Gets or sets the ID of the mentioned user.
         /// </summary>
         [JsonProperty("id")]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or sets display name of the referenced user.
@@ -316,7 +317,7 @@ namespace CoreTweet
         /// <returns>The ID of this instance.</returns>
         public override string ToString()
         {
-            return this.Id.ToString("D");
+            return this.Id?.ToString("D");
         }
     }
 }


### PR DESCRIPTION
Fixes a parsing problem: it seems that `UserMentionEntity.Id` can be null even if the user exists.