### PR TITLE
Remove doxygen from deps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "ExternalDependencies/doxygen"]
-	path = ExternalDependencies/doxygen
-	url = https://github.com/doxygen/doxygen.git
 [submodule "ExternalDependencies/nuget"]
 	path = ExternalDependencies/nuget
 	url = https://github.com/alexrp/nuget-unix.git

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,13 @@ MONO_PATH?=/usr/bin
 MONO_CS_SHELL_CONF?=~/.config/csharp
 
 EX_NUGET:=ExternalDependencies/nuget/bin/nuget
-EX_DOXYGEN:=ExternalDependencies/doxygen/bin/doxygen
 
 XBUILD?=$(MONO_PATH)/xbuild
 MONO?=$(MONO_PATH)/mono
 GIT?=$(shell which git)
 
 NUGET?=$(EX_NUGET)
-DOXYGEN?=$(shell hash doxygen 2>/dev/null || echo $(EX_DOXYGEN) && which doxygen)
+DOXYGEN?=$(shell hash doxygen 2>/dev/null || echo ":" && which doxygen)
 
 REST_APIS_GEN:=RestApisGen/bin/RestApisGen.exe
 
@@ -23,16 +22,12 @@ docs: external-tools binary
 
 # External tools
 
-external-tools: nuget doxygen ;
+external-tools: nuget ;
 
 nuget: $(NUGET) ;
-doxygen: $(DOXYGEN) ;
 
 submodule:
 	$(GIT) submodule update --init --recursive
-
-$(EX_DOXYGEN): submodule
-	cd ExternalDependencies/doxygen && ./configure && $(MAKE)
 
 $(EX_NUGET): submodule
 	cd ExternalDependencies/nuget && $(MAKE)

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Oh yes why don't you throw away any ```StatusUpdateOptions``` and it kinds???
 
 ## Latest Build Results
 
-* [Mono 3.2.1 on Ubuntu 12.04 LTS Server Edition 64 bit](https://travis-ci.org/CoreTweet/CoreTweet)
-* [Microsoft .NET Framework version 4.0.30319.34209 on Windows Azure "Small"](https://ci.appveyor.com/project/azyobuzin/CoreTweet)
+* [Mono on Linux](https://travis-ci.org/CoreTweet/CoreTweet)
+* [Microsoft .NET Framework on Windows Azure](https://ci.appveyor.com/project/azyobuzin/CoreTweet)
 
 ## Platforms
 
@@ -103,7 +103,7 @@ Or please download a binary from [Releases](https://github.com/CoreTweet/CoreTwe
 
 ## Build
 
-You can't build PCL/WindowsRT binaries on Mono (on Linux) because they requires non-free libraries.
+You can't build PCL/WindowsRT binaries on Mono (on Linux) because they require non-free libraries.
 
 ### On Windows
 
@@ -131,7 +131,7 @@ Set-ExecutionPolicy AllSigned
 * Mono 3.x or above
 * make
 * XBuild
-* Doxygen (if not installed, automatically build from source)
+* Doxygen (optional: used to generate documentation)
 
 #### Step
 


### PR DESCRIPTION
This removes doxygen from ```ExternalDependencies/``` and ```git submodule```.
Doxygen will still run on ```make``` if available.