### PR TITLE
Fix delaying streaming

### DIFF
--- a/CoreTweet.Shared/Streaming/StreamingObservable.cs
+++ b/CoreTweet.Shared/Streaming/StreamingObservable.cs
@@ -69,6 +69,8 @@ namespace CoreTweet.Streaming
                 // Make sure that all the operations are run in background
                 var firstTask = Task.Run(() => client.IncludedTokens.SendStreamingRequestAsync(GetMethodType(type), client.GetUrl(type), parameters, token), token);
 
+				// Setting the buffer size is a workaround for streaming delay
+				// https://github.com/CoreTweet/CoreTweet/pull/155
                 using (var res = await firstTask.ConfigureAwait(false))
                 using (var reader = new StreamReader(await res.GetResponseStreamAsync().ConfigureAwait(false), Encoding.UTF8, true, 16384))
                 {

--- a/CoreTweet.Shared/Streaming/StreamingObservable.cs
+++ b/CoreTweet.Shared/Streaming/StreamingObservable.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using static CoreTweet.Streaming.StreamingApi;
@@ -69,7 +70,7 @@ namespace CoreTweet.Streaming
                 var firstTask = Task.Run(() => client.IncludedTokens.SendStreamingRequestAsync(GetMethodType(type), client.GetUrl(type), parameters, token), token);
 
                 using (var res = await firstTask.ConfigureAwait(false))
-                using (var reader = new StreamReader(await res.GetResponseStreamAsync().ConfigureAwait(false)))
+                using (var reader = new StreamReader(await res.GetResponseStreamAsync().ConfigureAwait(false), Encoding.UTF8, true, 16384))
                 {
                     while (!reader.EndOfStream)
                     {


### PR DESCRIPTION
CoreTweetを0.8.2にアップデートしたところUWP環境でのストリーミングに遅延が発生するようになりました。

バージョン0.8.2からはUWP環境においてもSystem.Net.Httpを使用するようになっていますが、
UWP環境では[ReadAsStreamAsync](https://github.com/CoreTweet/CoreTweet/blob/master/CoreTweet.Shared/Internal/Request.Async.cs#L83)はWindowsRuntimeで実装されたStreamを[BufferedStream](https://github.com/dotnet/corefx/blob/6b9440735abc9c4e369376bca097766527971a7a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs)に内包した形で返却するようです。
BufferedStreamは内部にバッファされたものより大きい要求が来た際は元のStreamを[Readしに行きますが](https://github.com/dotnet/corefx/blob/6b9440735abc9c4e369376bca097766527971a7a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs#L513)、Readが帰ってくるまで受信済みのデータの一部がそのまま返却されないため、このような遅延が発生するのだと思われます。

これはStreamReader内部のバッファサイズをBufferedStreamのバッファサイズよりも大きくすることで対策することができます。
本プルリクはStreamReaderのバッファサイズをBufferedStreamのバッファサイズと同等にするものです。

説明が舌足らずですがよろしくおねがいします