### PR TITLE
Added link_color,theme,dnt  to params in the GET statuses/oembed

### DIFF
--- a/ApiTemplates/statuses.api
+++ b/ApiTemplates/statuses.api
@@ -121,6 +121,9 @@ endpoint Embed Oembed : Get statuses/oembed
         optional string lang
         optional string widget_type
         optional bool hide_tweet
+        optional string theme
+        optional string link_color
+        optional bool dnt
     }
 }
 


### PR DESCRIPTION
GET statuses/oembedのパラメータに以下を追加しました。

* link_color - ハッシュタグ/@hogehoge/URLのカラー指定
* theme - light/darkからウィジェットの色を指定
* dnt - Do not track 追跡可否を指定
