### PR TITLE
Fix properties of Account Activity API entities

### DIFF
--- a/ApiTemplates/test.api
+++ b/ApiTemplates/test.api
@@ -455,9 +455,7 @@ endpoint DirectMessageEventResponse New : POST direct_messages/events/new
                 },
                 "message_data": {
                     "text": $text,
-                    "quick_reply": {
-                        "type": $quick_reply_type
-                    },
+                    "quick_reply": $quick_reply,
                     "attachment": {
                         "type": $attachment_type,
                         "media": {
@@ -472,7 +470,7 @@ endpoint DirectMessageEventResponse New : POST direct_messages/events/new
     {
         required string text
         required string recipient_id
-        optional string quick_reply_type
+        optional QuickReply quick_reply
         optional string attachment_type
         optional long attachment_media_id
     }

--- a/ApiTemplates/welcomeMessages.api
+++ b/ApiTemplates/welcomeMessages.api
@@ -13,9 +13,7 @@ endpoint WelcomeMessageResponse New : Post direct_messages/welcome_messages/new
             "name": $name,
             "message_data": {
                 "text": $text,
-                "quick_reply": {
-                    "type": $quick_reply_type
-                },
+                "quick_reply": $quick_reply,
                 "attachment": {
                     "type": $attachment_type,
                     "media": {
@@ -28,7 +26,7 @@ endpoint WelcomeMessageResponse New : Post direct_messages/welcome_messages/new
     params
     {
         required string text
-        optional string quick_reply_type
+        optional QuickReply quick_reply
         optional string attachment_type
         optional long attachment_media_id
         optional string name

--- a/CoreTweet.Shared/AccountActivity/Events.cs
+++ b/CoreTweet.Shared/AccountActivity/Events.cs
@@ -188,6 +188,12 @@ namespace CoreTweet.AccountActivity
     [JsonObject]
     public class TweetCreateEvents : UserSpecificActivityEvent, IEnumerable<Status>
     {
+        [JsonProperty("user_has_blocked")]
+        public bool? UserHasBlocked { get; set; }
+
+        [JsonProperty("is_blocked_by")]
+        public long? IsBlockedBy { get; set; }
+
         [JsonProperty("tweet_create_events")]
         public Status[] Items { get; set; }
 

--- a/CoreTweet.Shared/Objects/DirectMessageEvents.cs
+++ b/CoreTweet.Shared/Objects/DirectMessageEvents.cs
@@ -126,22 +126,16 @@ namespace CoreTweet
         public MediaEntity Media { get; set; }
     }
 
-    public abstract class QuickReply : CoreBase
+    public class QuickReply : CoreBase
     {
         [JsonProperty("type")]
-        public virtual string Type { get; set; }
-    }
-
-    public class OptionsQuickReply : QuickReply
-    {
-        [JsonProperty("type")]
-        public override string Type { get; set; } = "options";
+        public string Type { get; set; }
 
         [JsonProperty("options")]
-        public OptionsQuickReplyOption[] Options { get; set; }
+        public QuickReplyOption[] Options { get; set; }
     }
 
-    public class OptionsQuickReplyOption : CoreBase
+    public class QuickReplyOption : CoreBase
     {
         [JsonProperty("label")]
         public string Label { get; set; }

--- a/CoreTweet.Shared/Objects/DirectMessageEvents.cs
+++ b/CoreTweet.Shared/Objects/DirectMessageEvents.cs
@@ -126,16 +126,22 @@ namespace CoreTweet
         public MediaEntity Media { get; set; }
     }
 
-    public class QuickReply : CoreBase
+    public abstract class QuickReply : CoreBase
     {
         [JsonProperty("type")]
-        public string Type { get; set; }
-
-        [JsonProperty("options")]
-        public QuickReplyOption[] Options { get; set; }
+        public virtual string Type { get; set; }
     }
 
-    public class QuickReplyOption : CoreBase
+    public class OptionsQuickReply : QuickReply
+    {
+        [JsonProperty("type")]
+        public override string Type { get; set; } = "options";
+
+        [JsonProperty("options")]
+        public OptionsQuickReplyOption[] Options { get; set; }
+    }
+
+    public class OptionsQuickReplyOption : CoreBase
     {
         [JsonProperty("label")]
         public string Label { get; set; }


### PR DESCRIPTION
- add missing properties on `TweetCreateEvents`
- resolve #172 
  - brought codes from https://github.com/CoreTweet/CoreTweet/issues/172#issuecomment-631505513
- make `QuickReply` abstract and shift `Options` property to `OptionsQuickReply`