### PR TITLE
Fix typo in v2 user lookup API

### DIFF
--- a/ApiTemplates/2/userLookup.api
+++ b/ApiTemplates/2/userLookup.api
@@ -69,7 +69,7 @@ endpoint UsersResponse GetUsers : Get users
     }
 }
 
-endpoint UserResponse GetUsersByUsernames : Get users/by
+endpoint UsersResponse GetUsersByUsernames : Get users/by
 {
     description
     {

--- a/build.ps1
+++ b/build.ps1
@@ -26,7 +26,7 @@ if($Help)
     echo "    Docs     ... Build documents only"
     echo "    Packages ... Build nupkgs only"
     echo "    Clean    ... Clean generated files"
-    echo "    ExecuteTemplete ... Generate RestApis.cs"
+    echo "    ExecuteTemplate ... Generate RestApis.cs"
     exit
 }
 


### PR DESCRIPTION
A small typo in the V2 user lookup API gave the `GetUsersByUsernames` method the wrong return type. I've tested this change manually and the returned data seems good.

Also fixed an unrelated typo in build.ps1.
