### PR TITLE
Deploy documentation workflow

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -19,6 +19,7 @@ jobs:
           path: website
           repository: CoreTweet/coretweet.github.io
           ref: autogentest
+          ssh-key: '${{ secrets.WEBSITE_DEPLOY_KEY }}'
 
       - name: Install Doxygen
         run: sudo apt-get update && sudo apt-get install -y doxygen

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -1,8 +1,6 @@
 name: Deploy Documentation
 
-on:
-  push:
-    branches: [docworkflow]
+on: workflow_dispatch
 
 jobs:
   deploy:
@@ -18,7 +16,7 @@ jobs:
         with:
           path: website
           repository: CoreTweet/coretweet.github.io
-          ref: autogentest
+          ref: master
           ssh-key: '${{ secrets.WEBSITE_DEPLOY_KEY }}'
 
       - name: Install Doxygen
@@ -44,4 +42,3 @@ jobs:
             git push
           fi
         working-directory: website
-

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -1,0 +1,46 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [docworkflow]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout CoreTweet
+        uses: actions/checkout@v2
+        with:
+          path: CoreTweet
+
+      - name: Checkout website
+        uses: actions/checkout@v2
+        with:
+          path: website
+          repository: CoreTweet/coretweet.github.io
+          ref: autogentest
+
+      - name: Install Doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen
+
+      - name: Run Doxygen
+        run: mkdir -p Release/docs && doxygen
+        working-directory: CoreTweet
+
+      - name: Copy files
+        run: |
+          rm -rf website/docs
+          cp -a CoreTweet/Release/docs/html website/docs
+          cp CoreTweet/README.md website/index.md
+
+      - name: Push
+        run: |
+          git add -A
+          if ! git diff --quiet --cached; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git commit -m "deploy: $GITHUB_SHA"
+            git push
+          fi
+        working-directory: website
+


### PR DESCRIPTION
Fix https://github.com/CoreTweet/coretweet.github.io/pull/1

After merging this PR to master, we can deploy documentation by clicking <samp>Run workflow</samp> button.

- [GitHub Actions: Manual triggers with workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)