### PR TITLE
feat(v2): Implement Timelines API and Follows lookup API

### DIFF
--- a/ApiTemplates/2/followsLookup.api
+++ b/ApiTemplates/2/followsLookup.api
@@ -1,0 +1,25 @@
+#root V2
+#namespace FollowsLookupApi
+#urlsuffix ""
+#description Provides a set of methods for the wrapper of Follows lookup API on Twitter API v2.
+
+endpoint UserCursoredResponse Following : Get users/{id}/following
+{
+    description
+    {
+        Returns a list of users the specified user ID is following.
+    }
+    returns
+    {
+        The User.
+    }
+    params
+    {
+        required long id
+        optional UserExpansions expansions
+        optional int max_results
+        optional string pagination_token
+        optional TweetFields tweet_fields="tweet.fields"
+        optional UserFields user_fields="user.fields"
+    }
+}

--- a/ApiTemplates/2/timelines.api
+++ b/ApiTemplates/2/timelines.api
@@ -1,0 +1,61 @@
+#root V2
+#namespace TimelinesApi
+#urlsuffix ""
+#description Provides a set of methods for the wrapper of Timelines API on Twitter API v2.
+
+endpoint TimelineResponse Tweets : Get users/{id}/tweets
+{
+    description
+    {
+        Returns Tweets composed by a single user, specified by the requested user ID. By default, the most recent 10 Tweets are returned per request with the default Tweet <c>id</c> and <c>text</c>. Using pagination, the most recent 3,200 Tweets can be retrieved.
+    }
+    returns
+    {
+        The Tweets with current timeline metadata.
+    }
+    params
+    {
+        required long id
+        optional DateTimeOffset end_time
+        optional TweetExcludes exclude
+        optional TweetExpansions expansions
+        optional int max_results
+        optional MediaFields media_fields="media.fields"
+        optional string pagination_token
+        optional PlaceFields place_fields="place.fields"
+        optional PollFields poll_fields="poll.fields"
+        optional long since_id
+        optional DateTimeOffset start_time
+        optional TweetFields tweet_fields="tweet.fields"
+        optional long until_id
+        optional UserFields user_fields="user.fields"
+    }
+}
+
+endpoint TimelineResponse Mentions : Get users/{id}/mentions
+{
+    description
+    {
+        Returns Tweets mentioning a single user specified by the requested user ID. By default, the most recent 10 Tweets are returned per request with the default Tweet <c>id</c> and <c>text</c>. Using pagination, the most recent 3,200 Tweets can be retrieved.
+    }
+    returns
+    {
+        The Tweets with current timeline metadata.
+    }
+    params
+    {
+        required long id
+        optional DateTimeOffset end_time
+        optional TweetExpansions expansions
+        optional int max_results
+        optional MediaFields media_fields="media.fields"
+        optional string pagination_token
+        optional PlaceFields place_fields="place.fields"
+        optional PollFields poll_fields="poll.fields"
+        optional long since_id
+        optional DateTimeOffset start_time
+        optional TweetFields tweet_fields="tweet.fields"
+        optional long until_id
+        optional UserFields user_fields="user.fields"
+    }
+}

--- a/CoreTweet.Shared/Internal/InternalUtils.cs
+++ b/CoreTweet.Shared/Internal/InternalUtils.cs
@@ -344,6 +344,9 @@ namespace CoreTweet.Core
             if (x is TweetMode || x is Bucket)
                 return x.ToString().ToLowerInvariant();
 
+            if (x is V2.TweetExcludes)
+                return V2.TweetExcludesExtensions.ToQueryString((V2.TweetExcludes)x);
+
             if (x is V2.TweetExpansions)
                 return V2.TweetExpansionsExtensions.ToQueryString((V2.TweetExpansions)x);
             if (x is V2.UserExpansions)

--- a/CoreTweet.Shared/V2/ApiProviders.cs
+++ b/CoreTweet.Shared/V2/ApiProviders.cs
@@ -56,6 +56,16 @@ namespace CoreTweet.V2
         public RecentSearchApi RecentSearchApi => new RecentSearchApi(this.Tokens);
 
         /// <summary>
+        /// Gets the wrapper of Timelines API on Twitter API v2.
+        /// </summary>
+        public TimelinesApi TimelinesApi => new TimelinesApi(this.Tokens);
+
+        /// <summary>
+        /// Gets the wrapper of Follows lookup API on Twitter API v2.
+        /// </summary>
+        public FollowsLookupApi FollowsLookupApi => new FollowsLookupApi(this.Tokens);
+
+        /// <summary>
         /// Gets the wrapper of Filtered stream API on Twitter API v2.
         /// </summary>
         public FilteredStreamApi FilteredStreamApi => new FilteredStreamApi(this.Tokens);

--- a/CoreTweet.Shared/V2/ResponseBase.cs
+++ b/CoreTweet.Shared/V2/ResponseBase.cs
@@ -44,4 +44,26 @@ namespace CoreTweet.V2
         /// </summary>
         public string Json { get; set; }
     }
+
+    public class CursoredResponseMeta : CoreBase
+    {
+        /// <summary>
+        /// The number of results returned in the response.
+        /// </summary>
+        [JsonProperty("result_count")]
+        public int ResultCount { get; set; }
+        // MEMO: the document is wrong (actual key is `result_count`, not `count`)
+
+        /// <summary>
+        /// A value that encodes the next 'page' of results that can be requested, via the <c>pagination_token</c> request parameter.
+        /// </summary>
+        [JsonProperty("next_token")]
+        public string NextToken { get; set; }
+
+        /// <summary>
+        /// A value that encodes the previous 'page' of results that can be requested, via the <c>pagination_token</c> request parameter.
+        /// </summary>
+        [JsonProperty("previous_token")]
+        public string PreviousToken { get; set; }
+    }
 }

--- a/CoreTweet.Shared/V2/Tweet.cs
+++ b/CoreTweet.Shared/V2/Tweet.cs
@@ -468,6 +468,21 @@ namespace CoreTweet.V2
         public Poll[] Polls { get; set; }
     }
 
+    public class TimelineResponseMeta : CursoredResponseMeta
+    {
+        /// <summary>
+        /// The Tweet ID of the most recent Tweet returned in the response.
+        /// </summary>
+        [JsonProperty("newest_id")]
+        public long NewestId { get; set; }
+
+        /// <summary>
+        /// The Tweet ID of the oldest Tweet returned in the response.
+        /// </summary>
+        [JsonProperty("oldest_id")]
+        public long OldestId { get; set; }
+    }
+
     public class TweetResponse : ResponseBase
     {
         [JsonProperty("data")]
@@ -490,6 +505,15 @@ namespace CoreTweet.V2
         /// </summary>
         [JsonProperty("includes")]
         public TweetResponseIncludes Includes { get; set; }
+    }
+
+    public class TimelineResponse : TweetsResponse
+    {
+        /// <summary>
+        /// This object contains information about the number of Tweets returned in the current request, and pagination details.
+        /// </summary>
+        [JsonProperty("meta")]
+        public TimelineResponseMeta Meta { get; set; }
     }
 
     /// <summary>
@@ -616,6 +640,36 @@ namespace CoreTweet.V2
                 builder.Append("referenced_tweets.id,");
             if ((value & TweetExpansions.ReferencedTweetsIdAuthorId) != 0)
                 builder.Append("referenced_tweets.id.author_id,");
+
+            return builder.ToString(0, builder.Length - 1);
+        }
+    }
+
+    /// <summary>
+    /// List of the types of Tweets to exclude from the response. When <see cref="TweetExcludes.Retweets"/> is used, the maximum historical Tweets returned is still 3200. When the <see cref="TweetExcludes.Replies"/> parameter is used for any value, only the most recent 800 Tweets are available.
+    /// </summary>
+    [Flags]
+    public enum TweetExcludes
+    {
+        None     = 0x00000000,
+        Retweets = 0x00000001,
+        Replies  = 0x00000002,
+        All      = 0x00000003,
+    }
+
+    public static class TweetExcludesExtensions
+    {
+        public static string ToQueryString(this TweetExcludes value)
+        {
+            if (value == TweetExcludes.None)
+                return "";
+
+            var builder = new StringBuilder();
+
+            if ((value & TweetExcludes.Retweets) != 0)
+                builder.Append("retweets,");
+            if ((value & TweetExcludes.Replies) != 0)
+                builder.Append("replies,");
 
             return builder.ToString(0, builder.Length - 1);
         }

--- a/CoreTweet.Shared/V2/User.cs
+++ b/CoreTweet.Shared/V2/User.cs
@@ -218,6 +218,15 @@ namespace CoreTweet.V2
         public UserResponseIncludes Includes { get; set; }
     }
 
+    public class UserCursoredResponse : UsersResponse
+    {
+        /// <summary>
+        /// This object contains information about the number of users returned in the current request, and pagination details.
+        /// </summary>
+        [JsonProperty("meta")]
+        public CursoredResponseMeta Meta { get; set; }
+    }
+
     /// <summary>
     /// List of additional fields to return in the User object. By default, the endpoint does not return any user field.
     /// </summary>

--- a/RestApisGen/DataType.cs
+++ b/RestApisGen/DataType.cs
@@ -9,7 +9,7 @@ namespace RestApisGen
 {
     public class ApiEndpoint
     {
-        private static readonly string[] valueTypes = { "int", "long", "byte", "double", "bool", "DateTimeOffset", "UploadMediaType", "TweetMode", "Bucket", "Format", "TweetExpansions", "UserExpansions", "MediaFields", "PlaceFields", "PollFields", "TweetFields", "UserFields" };
+        private static readonly string[] valueTypes = { "int", "long", "byte", "double", "bool", "DateTimeOffset", "UploadMediaType", "TweetMode", "Bucket", "Format", "TweetExcludes", "TweetExpansions", "UserExpansions", "MediaFields", "PlaceFields", "PollFields", "TweetFields", "UserFields" };
 
         public string Name { get; set; }
 


### PR DESCRIPTION
Implements a wrapper of endpoints called [Timelines API](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference) and [Follows lookup API](https://developer.twitter.com/en/docs/twitter-api/users/follows/api-reference) released today (JST).

To Do
--

These endpoints should be wrapped with `Cursored<T>`, but the current implementation didn't follows it yet.
