### PR TITLE
Fix writing nupkg to wrong directory on Windows

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,6 @@ See also: https://github.com/CoreTweet/CoreTweet
 
   <PropertyGroup>
     <RepoRootDir>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)"))</RepoRootDir>
-    <NupkgsDir>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)/Release/"))</NupkgsDir>
+    <NupkgsDir>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)/Release"))</NupkgsDir>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
`"$(NupkgsDir)" --version-suffix "$(VersionSuffix)"` is interpreted like `C:\Path\To\Release" --version-suffix beta.3` on Windows. This PR removes the trailing slash of `NupkgsDir`. I think the trailing slash does not affect any operation.